### PR TITLE
bump up pytd 0.8.0 for twitter search

### DIFF
--- a/integration-box/twitter-search/twitter-archiver.py
+++ b/integration-box/twitter-search/twitter-archiver.py
@@ -3,7 +3,7 @@ from datetime import datetime as dt
 from mapping import mapping as mp
 from time import sleep
 
-os.system(f"{sys.executable} -m pip install -U pytd==0.6.2")
+os.system(f"{sys.executable} -m pip install -U pytd==0.8.0")
 os.system(f"{sys.executable} -m pip install TwitterSearch")
 
 import pytd


### PR DESCRIPTION
In case of 0.6.2 occurred error messages.
> ValueError: Bulk import API does not support `append`

To fix it, bump up pytd latest version. 