### PR TITLE
remove sequence ang change file name

### DIFF
--- a/td/gcs/export_gcs.dig
+++ b/td/gcs/export_gcs.dig
@@ -7,8 +7,7 @@ timezone: UTC
   result_connection: YOUR_GCS_CONNECTION_NAME
   result_settings:
     bucket: BUCKET_NAME
-    path_prefix: /filename.csv
-    sequence_format: .%1d
+    path_prefix: /filename.csv.gz
     format: csv
     header_line: true
     delimiter: ","


### PR DESCRIPTION
## What I have changed

I have changed below two points of export_gcs.dig

1. remove sequence_format: .%1d****
2. Change path_prefix option /filename.csv to */filename.csv.gz*

## Purposes

For 1, this option is not already effective.
For 2, to avoid make users confused as with previous setting seem to generate csv file  even though the file is gz file .