### PR TITLE
Add Python example of setting WF variable

### DIFF
--- a/integration-box/python/py_scripts/examples.py
+++ b/integration-box/python/py_scripts/examples.py
@@ -12,3 +12,8 @@ def print_env():
 def import_another_file():
     import other_scripts as o
     o.print_path()
+
+
+def store_workflow_env(msg):
+    import digdag
+    digdag.env.store({"my_msg": msg})

--- a/integration-box/python/simple.dig
+++ b/integration-box/python/simple.dig
@@ -17,3 +17,13 @@
     py>: py_scripts.examples.import_another_file
     docker:
         image: "digdag/digdag-python:3.7"
+
++simple_with_workflow_env:
+    +store_msg:
+        py>: py_scripts.examples.store_workflow_env
+        msg: "Hello World"
+        docker:
+            image: "digdag/digdag-python:3.7"
+
+    +restore_msg:
+        echo>: ${my_msg}


### PR DESCRIPTION
This can be a part of the Box, because `digdag.env.store` is used in the Simple Python Example template when we create a new workflow in the console:

<img width="640" alt="Screen Shot 2019-11-22 at 10 29 41" src="https://user-images.githubusercontent.com/853567/69450971-30a6d100-0d13-11ea-95a9-5acb5b039293.png">
