### PR TITLE
refactor: stop appending dataframe

### DIFF
--- a/integration-box/rss/py_scripts/tasks.py
+++ b/integration-box/rss/py_scripts/tasks.py
@@ -9,29 +9,21 @@ import pandas as pd
 os.system(f"{sys.executable} -m pip install feedparser")
 os.system(f"{sys.executable} -m pip install -U pytd==1.0.0")
 
-import pytd
-import feedparser
-
-
 TD_APIKEY = os.environ.get("td_apikey")
 TD_ENDPOINT = os.environ.get("td_endpoint")
 
 
 def rss_import(dest_db: str, dest_table: str, rss_url_list):
-    df = pd.DataFrame(columns=["title", "description", "link"])
+    import pytd
+    import feedparser
+
+    posts = []
     for rss_url in rss_url_list:
         d = feedparser.parse(rss_url)
         for entry in d.entries:
-            tmp_se = pd.Series(
-                [entry.title, entry.description, entry.link], index=df.columns
-            )
-            df = df.append(tmp_se, ignore_index=True)
+            posts.append((entry.title, entry.description, entry.link))
 
-    client = pytd.Client(
-        apikey=TD_APIKEY,
-        endpoint=TD_ENDPOINT,
-        database=dest_db,
-        default_engine="presto",
-    )
+    df = pd.DataFrame(posts, columns=["title", "description", "link"])
+    client = pytd.Client(apikey=TD_APIKEY, endpoint=TD_ENDPOINT, database=dest_db)
     client.create_database_if_not_exists(dest_db)
     client.load_table_from_dataframe(df, dest_table, if_exists="append")

--- a/integration-box/rss/rss_import.dig
+++ b/integration-box/rss/rss_import.dig
@@ -9,10 +9,12 @@ schedule:
 +step1:
   docker:
     image: "digdag/digdag-python:3.7"
-  py>: tasks.rss_import
+  py>: py_scripts.tasks.rss_import
   dest_db: ${td.database}
   dest_table: ${td.table}
-  rss_url_list: ['https://www.vogue.co.jp/rss/vogue', 'https://feeds.dailyfeed.jp/feed/s/7/887.rss']
+  rss_url_list:
+    - 'https://www.vogue.co.jp/rss/vogue'
+    - 'https://feeds.dailyfeed.jp/feed/s/7/887.rss'
   _env:
     td_apikey: ${secret:td.apikey}
     td_endpoint: ${secret:td.apiserver}


### PR DESCRIPTION
Since pandas DataFrame `append` forces to create numpy array each time, it is inefficient to df.append in for loop.