### PR TITLE
Add TBox for CLTV prediction

### DIFF
--- a/machine-learning-box/customer-lifetime-value/README.md
+++ b/machine-learning-box/customer-lifetime-value/README.md
@@ -52,7 +52,7 @@ A derived attribute `recency` is the number of days between the first order and 
 
 The output of workflow is a table that contains predicted CLTV for a subset of customers:
 
-| customerid<br/>`long` | predicted_cltvr<br/>`double` |
+| customerid<br/>`long` | predicted_cltv<br/>`double` |
 |:---:|:---:|
 |12355|68.84149528775471|
 |12356|172.29478943269208|

--- a/machine-learning-box/customer-lifetime-value/README.md
+++ b/machine-learning-box/customer-lifetime-value/README.md
@@ -1,0 +1,74 @@
+Customer Lifetime Value Prediction Template
+===
+
+Predicting Customer Lifetime Value (CLTV) allows you to efficiently identify high-value customers and understand their characteristics. Eventually, you can effectively optimize your day-to-day marketing activities without missing important highly-engaged customers.
+
+## Input
+
+As an online retailer, assume we have [a `source` table](./config/general.yml#L3) that represents customer's order histories as follows:
+
+| InvoiceNo<br/>`string` | InvoiceDate<br/>`string` | CustomerID<br/>`long` | Country<br/>`string` | StockCode<br/>`string` | Description<br/>`string` | UnitPrice <br/>`double` | Quantity<br/>`long` | 
+|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| 536365 | 2010/12/01 8:26 | 17850 | United Kingdom | 85123A | WHITE HANGING HEART T-LIGHT HOLDER | 2.55 | 6 |
+| 536365 | 2010/12/01 8:26 | 17850 | United Kingdom | 71053 | WHITE METAL LANTERN | 3.39 | 6 |
+| 536365 | 2010/12/01 8:26 | 17850 | United Kingdom | 84406B | CREAM CUPID HEARTS COAT HANGER | 2.75 | 8 |
+| ... |...|...| ...|...|...|...|...|
+| C536391 | 2010/12/01 10:24 | 17548 | United Kingdom | 22556 | PLASTERS IN TIN CIRCUS PARADE  | 1.65 | -12 |
+| ... |...|...| ...|...|...|...|...|
+
+Here, each row represents single item (i.e., **StockCode**) in a basket corresponding to single order (i.e., **InvoiceNo**). That is, a CLTV can be calculated by **a sum of (UnitPrice * Quantity)** for unique CustomerID.
+
+> **Note:** Negative **Quantity** represents returned items.
+
+## Workflow
+
+First, prepare the data as follows:
+
+1. Download `Online Retail.xlsx` from [UCI Machine Learning Repository: Online Retail Data Set](http://archive.ics.uci.edu/ml/datasets/Online+Retail). Our data model explained above is fully based on this public dataset.
+2. Convert the data into a CSV file.
+3. Import the CSV file to a Treasure Data table. 
+
+Next, set your database and table name to [`config/general.yml`](./config/general.yml).
+
+Finally, run a ready-made workflow template for CLTV prediction:
+
+```sh
+$ td wf push cltv-prediction # push workflow to TD
+$ td wf start cltv-prediction predict --session now -p apikey=${YOUR_TD_API_KEY}
+```
+
+In the middle of the workflow, we calculate CLTV for every single **CustomerID** and enrich their attributes with basic statistics:
+
+| customerid<br/>`long` | cltv<br/>`double` | country<br/>`string` | recency<br/>`long` | avg_basket_value<br/>`double` | avg_basket_size<br/>`long` | cnt_returns<br/>`long` | has_returned<br/>`boolean` |
+|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| 14001 | 2030.33 | United Kingdom | 327 | 681.0266666666666 | 320.6666666666667 | 1 | 1 |
+| 14911 | 132572.6200000001 |  EIRE | 372 | 715.5475621890546 | 400.5721393034826 | 47 | 1 |
+| 18144 | 2888.7499999999995 | United Kingdom | 365 | 240.72916666666666 | 111.91666666666667 | 0 | 0 |
+| ... |...|...| ...|...|...|...|...|
+
+A derived attribute `recency` is the number of days between the first order and last order. 
+
+## Output
+
+The output of workflow is a table that contains predicted CLTV for a subset of customers:
+
+| customerid<br/>`long` | predicted_cltvr<br/>`double` |
+|:---:|:---:|
+|12355|68.84149528775471|
+|12356|172.29478943269208|
+|12357|151.84542283221555|
+| ... | ... |
+
+Meanwhile, the Workflow execution log tells you the accuracy of prediction:
+
+```
+Accuracy RMSE: 4623.584016620842, MAE: 1777.0782472268297
+```
+
+It's time to tweak your model with custom hyper-parameters in [`queries/train_regressor.sql`](./queries/train_regressor.sql). Notice that this template uses a linear regressor to make CLTV prediction.
+
+[Contact us](https://www.treasuredata.com/contact_us) if you interested in [our paid consulting service](https://docs.treasuredata.com/articles/data-science-consultation).
+
+## Reference
+
+- [Predicting Customer Lifetime Value with AI Platform: training the models](https://cloud.google.com/solutions/machine-learning/clv-prediction-with-offline-training-train)

--- a/machine-learning-box/customer-lifetime-value/README.md
+++ b/machine-learning-box/customer-lifetime-value/README.md
@@ -67,8 +67,6 @@ Accuracy RMSE: 4623.584016620842, MAE: 1777.0782472268297
 
 It's time to tweak your model with custom hyper-parameters in [`queries/train_regressor.sql`](./queries/train_regressor.sql). Notice that this template uses a linear regressor to make CLTV prediction.
 
-[Contact us](https://www.treasuredata.com/contact_us) if you interested in [our paid consulting service](https://docs.treasuredata.com/articles/data-science-consultation).
-
 ## Reference
 
 - [Predicting Customer Lifetime Value with AI Platform: training the models](https://cloud.google.com/solutions/machine-learning/clv-prediction-with-offline-training-train)

--- a/machine-learning-box/customer-lifetime-value/README.md
+++ b/machine-learning-box/customer-lifetime-value/README.md
@@ -5,6 +5,8 @@ Predicting Customer Lifetime Value (CLTV) allows you to efficiently identify hig
 
 ## Input
 
+*Data source: [UCI Machine Learning Repository: Online Retail Data Set](http://archive.ics.uci.edu/ml/datasets/Online+Retail).*
+
 As an online retailer, assume we have [a `source` table](./config/general.yml#L3) that represents customer's order histories as follows:
 
 | InvoiceNo<br/>`string` | InvoiceDate<br/>`string` | CustomerID<br/>`long` | Country<br/>`string` | StockCode<br/>`string` | Description<br/>`string` | UnitPrice <br/>`double` | Quantity<br/>`long` | 
@@ -22,22 +24,22 @@ Here, each row represents single item (i.e., **StockCode**) in a basket correspo
 
 ## Workflow
 
-First, prepare the data as follows:
+Set your database and table name to [`config/general.yml`](./config/general.yml).
 
-1. Download `Online Retail.xlsx` from [UCI Machine Learning Repository: Online Retail Data Set](http://archive.ics.uci.edu/ml/datasets/Online+Retail). Our data model explained above is fully based on this public dataset.
-2. Convert the data into a CSV file.
-3. Import the CSV file to a Treasure Data table. 
-
-Next, set your database and table name to [`config/general.yml`](./config/general.yml).
-
-Finally, run a ready-made workflow template for CLTV prediction:
+Run a ready-made workflow template for CLTV prediction:
 
 ```sh
 $ td wf push cltv-prediction # push workflow to TD
-$ td wf start cltv-prediction predict --session now -p apikey=${YOUR_TD_API_KEY}
+$ td wf secrets --project cltv-prediction --set td.apikey td.apiserver
+$ td wf start cltv-prediction predict --session now 
 ```
 
-In the middle of the workflow, we calculate CLTV for every single **CustomerID** and enrich their attributes with basic statistics:
+|Variable|Description|Example|
+|:---|:---|:---|
+|`td.apikey`|TD API key to be used in the script. Access Type must be `Master Key`.|`1234/abcdefghijklmnopqrstuvwxyz1234567890`|
+|`td.apiserver`|TD API endpoint starting with `https://`.|`https://api.treasuredata.com`|
+
+In the middle of the workflow, we import the [Online Retail Data Set](http://archive.ics.uci.edu/ml/datasets/Online+Retail) to a table, calculate CLTV for every single **CustomerID**, and enrich their attributes with basic statistics:
 
 | customerid<br/>`long` | cltv<br/>`double` | country<br/>`string` | recency<br/>`long` | avg_basket_value<br/>`double` | avg_basket_size<br/>`long` | cnt_returns<br/>`long` | has_returned<br/>`boolean` |
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|

--- a/machine-learning-box/customer-lifetime-value/config/general.yml
+++ b/machine-learning-box/customer-lifetime-value/config/general.yml
@@ -5,3 +5,6 @@ source: online_retail # input table
 # Decide how many samples are used for training
 # test_sample_rate = 1.0 - train_sample_rate
 train_sample_rate: 0.8
+
+# Split time-series purchase history into train and test data
+threshold_date: 2011-06-01

--- a/machine-learning-box/customer-lifetime-value/config/general.yml
+++ b/machine-learning-box/customer-lifetime-value/config/general.yml
@@ -1,6 +1,6 @@
 # Data:
-database: your_database # working database
-source: online_retail # input table
+database: online_retail # working database
+source: transactions # input table
 
 # Decide how many samples are used for training
 # test_sample_rate = 1.0 - train_sample_rate

--- a/machine-learning-box/customer-lifetime-value/config/general.yml
+++ b/machine-learning-box/customer-lifetime-value/config/general.yml
@@ -1,0 +1,7 @@
+# Data:
+database: your_database # working database
+source: online_retail # input table
+
+# Decide how many samples are used for training
+# test_sample_rate = 1.0 - train_sample_rate
+train_sample_rate: 0.8

--- a/machine-learning-box/customer-lifetime-value/data.py
+++ b/machine-learning-box/customer-lifetime-value/data.py
@@ -1,0 +1,33 @@
+import os
+import sys
+os.system(f"{sys.executable} -m pip install -U pytd==1.3.0 xlrd")
+
+
+def import_table(database, table):
+    import pandas as pd
+    import pytd
+
+    # http://archive.ics.uci.edu/ml/datasets/Online+Retail#
+    url = "http://archive.ics.uci.edu/ml/machine-learning-databases/00352/Online%20Retail.xlsx"
+
+    df = pd.read_excel(url, dtype={
+        "InvoiceNo": str,
+        "InvoiceDate": str,
+        "CustomerID": float,
+        "Country": str,
+        "StockCode": str,
+        "Description": str,
+        "UnitPrice": float,
+        "Quantity": int
+    })
+    df = df.loc[pd.notnull(df.CustomerID)]
+    df.CustomerID = df.CustomerID.astype(int)
+
+    client = pytd.Client(apikey=os.environ.get('TD_API_KEY'),
+                         endpoint=os.environ.get('TD_API_SERVER'),
+                         database=database)
+    client.load_table_from_dataframe(df, table, if_exists="overwrite")
+
+
+if __name__ == "__main__":
+    import_table("takuti", "transactions")

--- a/machine-learning-box/customer-lifetime-value/predict.dig
+++ b/machine-learning-box/customer-lifetime-value/predict.dig
@@ -1,0 +1,58 @@
+_export:
+  !include : config/general.yml
+  td:
+    apikey: ${apikey}
+    database: ${database}
+
++prepare:
+  td>: queries/prepare_data.sql
+  create_table: cltv
+
++shuffle:
+  td>: queries/shuffle.sql
+  create_table: cltv_shuffled
+  engine: hive
+
++split:
+  _parallel: true
+
+  +train:
+    td>: queries/split_train.sql
+    create_table: cltv_train
+
+  +test:
+    td>: queries/split_test.sql
+    create_table: cltv_test
+
++vectorize:
+  _parallel: true
+
+  +train:
+    td>: queries/vectorize.sql
+    target: train
+    create_table: cltv_train_vectorized
+    engine: hive
+
+  +test:
+    td>: queries/vectorize.sql
+    target: test
+    create_table: cltv_test_vectorized
+    engine: hive
+
++train:
+  td>: queries/train_regressor.sql
+  create_table: regressor
+  engine: hive
+
++predict:
+  td>: queries/predict_regressor.sql
+  create_table: predictions
+  engine: hive
+
++evaluate:
+  td>: queries/evaluate.sql
+  engine: hive
+  store_last_results: true
+
++show_accuracy:
+  echo>: "Accuracy RMSE: ${td.last_results.rmse}, MAE: ${td.last_results.mae}"

--- a/machine-learning-box/customer-lifetime-value/predict.dig
+++ b/machine-learning-box/customer-lifetime-value/predict.dig
@@ -1,7 +1,6 @@
 _export:
   !include : config/general.yml
   td:
-    apikey: ${apikey}
     database: ${database}
 
 +prepare:

--- a/machine-learning-box/customer-lifetime-value/predict.dig
+++ b/machine-learning-box/customer-lifetime-value/predict.dig
@@ -5,7 +5,7 @@ _export:
     database: ${database}
 
 +prepare:
-  td>: queries/prepare_data.sql
+  td>: queries/preprocess.sql
   create_table: cltv
 
 +shuffle:

--- a/machine-learning-box/customer-lifetime-value/predict.dig
+++ b/machine-learning-box/customer-lifetime-value/predict.dig
@@ -3,6 +3,16 @@ _export:
   td:
     database: ${database}
 
++data:
+  py>: data.import_table
+  database: ${database}
+  table: ${source}
+  _env:
+    TD_API_KEY: ${secret:td.apikey}
+    TD_API_SERVER: ${secret:td.apiserver}
+  docker:
+      image: "digdag/digdag-python:3.7"
+
 +prepare:
   td>: queries/preprocess.sql
   create_table: cltv

--- a/machine-learning-box/customer-lifetime-value/queries/evaluate.sql
+++ b/machine-learning-box/customer-lifetime-value/queries/evaluate.sql
@@ -1,0 +1,8 @@
+select
+  rmse(p.predicted_cltv, t.cltv) as rmse,
+  mae(p.predicted_cltv, t.cltv) as mae
+from
+  predictions p
+join
+  cltv_test t
+  on p.customerid = t.customerid

--- a/machine-learning-box/customer-lifetime-value/queries/predict_regressor.sql
+++ b/machine-learning-box/customer-lifetime-value/queries/predict_regressor.sql
@@ -1,0 +1,18 @@
+with features_exploded as (
+  select
+    t.customerid,
+    extract_feature(t.fv) as feature,
+    extract_weight(t.fv) as value
+  from
+    cltv_test_vectorized t
+    LATERAL VIEW explode(add_bias(features)) t as fv
+)
+-- DIGDAG_INSERT_LINE
+select
+  t.customerid,
+  sum(m.weight * t.value) as predicted_cltv
+from
+  features_exploded t
+  LEFT OUTER JOIN regressor m ON (t.feature = m.feature)
+group by
+  t.customerid

--- a/machine-learning-box/customer-lifetime-value/queries/prepare_data.sql
+++ b/machine-learning-box/customer-lifetime-value/queries/prepare_data.sql
@@ -1,0 +1,63 @@
+with cltv as (
+  select
+    customerid,
+    max_by(country, invoicedate) as country,
+    sum(unitprice * quantity) as cltv,
+    max(invoicedate) as date_last_order,
+    min(invoicedate) as date_first_order
+  from
+    ${source}
+  group by
+    1
+),
+orders as (
+  select
+    customerid,
+    avg(basket_value) as avg_basket_value,
+    avg(basket_size) as avg_basket_size
+  from (
+    select
+      customerid,
+      invoiceno,
+      sum(unitprice * quantity) as basket_value,
+      sum(quantity) as basket_size
+    from
+      ${source}
+    where
+      quantity > 0
+    group by
+      1, 2
+  ) t1
+  group by
+    1
+),
+returns as (
+  select
+    customerid,
+    count(distinct invoiceno) as cnt_returns
+  from
+    ${source}
+  where
+    quantity < 0
+  group by
+    1
+)
+select
+  t1.customerid,
+  t1.cltv,
+  t1.country,
+  date_diff('day', date_parse(t1.date_first_order, '%Y-%m-%d %T.%f'), date_parse(t1.date_last_order, '%Y-%m-%d %T.%f')) as recency,
+  t2.avg_basket_value,
+  t2.avg_basket_size,
+  coalesce(t3.cnt_returns, 0) as cnt_returns,
+  if(t3.cnt_returns is null, 0, 1) as has_returned
+from
+  cltv t1
+left join
+  orders t2
+  on t1.customerid = t2.customerid
+left join
+  returns t3
+  on t1.customerid = t3.customerid
+where
+  t1.cltv > 0

--- a/machine-learning-box/customer-lifetime-value/queries/preprocess.sql
+++ b/machine-learning-box/customer-lifetime-value/queries/preprocess.sql
@@ -50,7 +50,7 @@ select
   t1.cltv,
   t1.country,
   -- features for training; aggregated in a training period before ${threshold_date}
-  date_diff('day', date_parse(t2.date_first_order, '%Y-%m-%d %T.%f'), date_parse(t2.date_last_order, '%Y-%m-%d %T.%f')) as recency,
+  date_diff('day', date_parse(t2.date_first_order, '%Y-%m-%d %T'), date_parse(t2.date_last_order, '%Y-%m-%d %T')) as recency,
   t2.avg_basket_value,
   t2.avg_basket_size,
   coalesce(t3.cnt_returns, 0) as cnt_returns,

--- a/machine-learning-box/customer-lifetime-value/queries/shuffle.sql
+++ b/machine-learning-box/customer-lifetime-value/queries/shuffle.sql
@@ -1,0 +1,14 @@
+select
+  rand(31) as rnd,
+  customerid,
+  cltv,
+  country,
+  recency,
+  avg_basket_value,
+  avg_basket_size,
+  cnt_returns,
+  has_returned
+from
+  cltv
+cluster by
+  rand(43)

--- a/machine-learning-box/customer-lifetime-value/queries/split_test.sql
+++ b/machine-learning-box/customer-lifetime-value/queries/split_test.sql
@@ -1,0 +1,6 @@
+select
+  *
+from
+  cltv_shuffled
+where
+  rnd > ${train_sample_rate}

--- a/machine-learning-box/customer-lifetime-value/queries/split_train.sql
+++ b/machine-learning-box/customer-lifetime-value/queries/split_train.sql
@@ -1,0 +1,6 @@
+select
+  *
+from
+  cltv_shuffled
+where
+  rnd <= ${train_sample_rate}

--- a/machine-learning-box/customer-lifetime-value/queries/train_regressor.sql
+++ b/machine-learning-box/customer-lifetime-value/queries/train_regressor.sql
@@ -1,0 +1,7 @@
+select
+  train_regressor(
+    add_bias(features),
+    cltv
+  )
+from
+  cltv_train_vectorized

--- a/machine-learning-box/customer-lifetime-value/queries/vectorize.sql
+++ b/machine-learning-box/customer-lifetime-value/queries/vectorize.sql
@@ -1,0 +1,18 @@
+select
+  customerid,
+  array_concat(
+    categorical_features(
+      array("country", "has_returned"),
+      country, has_returned
+    ),
+    quantitative_features(
+      array("recency", "avg_basket_value", "avg_basket_size", "cnt_returns"),
+      ln(recency + 1),
+      ln(avg_basket_value + 1),
+      ln(avg_basket_size + 1),
+      ln(cnt_returns + 1)
+    )
+  ) as features,
+  cltv
+from
+  cltv_${target}


### PR DESCRIPTION
This template runs CLTV prediction in a similar way to: https://cloud.google.com/solutions/machine-learning/clv-prediction-with-offline-training-intro

Dataset: [Online Retail Data Set](http://archive.ics.uci.edu/ml/datasets/Online+Retail) provided by UCI.