### PR TITLE
change to refreshing all data

### DIFF
--- a/data-box/tapad-cross-device-graph/config/load.yml
+++ b/data-box/tapad-cross-device-graph/config/load.yml
@@ -28,4 +28,4 @@ filters:
   from_value:
     mode: upload_time
 out:
-  mode: append
+  mode: replace


### PR DESCRIPTION
TAPAD device-graph-file contains all results data. So it's better to replace every time.