### PR TITLE
Revise TD doc URL

### DIFF
--- a/analytics-box/fuzzy-matching/README.md
+++ b/analytics-box/fuzzy-matching/README.md
@@ -1,15 +1,15 @@
 
-# Fuzzy Matching to identify similar profiles in treasure data  
-  
-This project provides the workflows necessary to use Fuzzy Matching algorithms like Levenshtein to do probabilistic matching of the profiles. Once higher probability of similar profiles is gathered, they can further be compared with behavioral data using deterministic matching. Report is generated to give an overview of similar profiles and relevant profiles then can be chosen to stay into treasure data platform. For more description , please refer to the Treasure Box overview page for [Fuzzy Matching](https://boxes.treasuredata.com/hc/en-us/articles/360032618714-Fuzzy-Matching-on-PII-data)  
-  
-## Getting Started  
+# Fuzzy Matching to identify similar profiles in treasure data
+
+This project provides the workflows necessary to use Fuzzy Matching algorithms like Levenshtein to do probabilistic matching of the profiles. Once higher probability of similar profiles is gathered, they can further be compared with behavioral data using deterministic matching. Report is generated to give an overview of similar profiles and relevant profiles then can be chosen to stay into treasure data platform. For more description , please refer to the Treasure Box overview page for [Fuzzy Matching](https://boxes.treasuredata.com/hc/en-us/articles/360032618714-Fuzzy-Matching-on-PII-data)
+
+## Getting Started
 
 1. Download this folder locally.
-2. Use [TD Toolbelt](https://support.treasuredata.com/hc/en-us/articles/360001262207) to upload this folder as a Treasure Workflow project into your Treasure data account  
+2. Use [TD Toolbelt](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083651/Treasure+Workflow+Quick+Start+using+TD+Toolbelt+in+a+CLI) to upload this folder as a Treasure Workflow project into your Treasure data account
 3. Provide the database name ,table name(ex. user_master with first and last name information) and column name with information of first and last name in the demo_fuzzy.dig file as variables
 4. Run the demo_fuzzy.dig file
-  
+
 ### How it works
 
 Here is a brief description what each task in the workflow do
@@ -23,8 +23,8 @@ Here is a brief description what each task in the workflow do
 7. Create a Match store which holds the information of group_key and index of corresponding similar profiles as a metadata for easy retrieval of profiles
 8. Similar profiles gathered based on the cut off value can be visualized using any reporting tool
 
-### Outputs  
-  
+### Outputs
+
 Here are snapshots how this workflow results in TD.
 
 ### Before Data Cleaning

--- a/data-box/customer-profile-enrichment/README.md
+++ b/data-box/customer-profile-enrichment/README.md
@@ -12,7 +12,7 @@ This project provides the workflows necessary to enrich customer profiles with s
 ----
 ## Implementation
 1. Download this folder locally
-2. Use [TD Toolbelt](https://support.treasuredata.com/hc/en-us/articles/360001262207-Treasure-Workflow-Quick-Start-using-TD-Toolbelt-in-a-CLI) to upload this folder as a Treasure Workflow project in your Treasure Data account
+2. Use [TD Toolbelt](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083651/Treasure+Workflow+Quick+Start+using+TD+Toolbelt+in+a+CLI) to upload this folder as a Treasure Workflow project in your Treasure Data account
 3. Define the variables listed below to specify what data to process in order to enrich the necessary customer profiles
 
 ----

--- a/data-box/email-validation/README.md
+++ b/data-box/email-validation/README.md
@@ -8,7 +8,7 @@ This box provides a sample SQL query that can be used to assess whether or not a
 ----
 ## Implementation
 1. Download this folder locally
-2. Use [TD Toolbelt](https://support.treasuredata.com/hc/en-us/articles/360001262207-Treasure-Workflow-Quick-Start-using-TD-Toolbelt-in-a-CLI) to upload this folder as a Treasure Workflow project in your Treasure Data account
+2. Use [TD Toolbelt](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083651/Treasure+Workflow+Quick+Start+using+TD+Toolbelt+in+a+CLI) to upload this folder as a Treasure Workflow project in your Treasure Data account
 3. Define the variables listed below to specify what data to process in order to enrich the necessary customer profiles
 
 ----

--- a/integration-box/csv_import_via_http/README.md
+++ b/integration-box/csv_import_via_http/README.md
@@ -9,7 +9,7 @@ This workflow project including CustomScript (Python) enables you to import csv 
 - column_setting_file: set CSV setting file name.
 
 ## Set apikey as secret ()
-https://support.treasuredata.com/hc/en-us/articles/360001266788-Workflows-Secrets-Management
+https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
 
 ## Edit csv_setting.json
 You can change behavior followings.
@@ -17,10 +17,10 @@ You can change behavior followings.
 - specify ignoring column to import. If you want to ignore, you should change to true from false.
 
 ## update workflow project to TreasureData
-Submit workflow to TreasureData.  
-https://support.treasuredata.com/hc/en-us/articles/360001262207-Treasure-Workflow-Quick-Start-using-TD-Toolbelt-in-a-CLI#Submit%20the%20workflow%20to%20Treasure%20Data
+Submit workflow to TreasureData.
+https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083651/Treasure+Workflow+Quick+Start+using+TD+Toolbelt+in+a+CLI
 
 ## Appendix
-You can specify http settings in detail depend on pandas.read_csv function (encoding, compression, and so on).  
-like `df = pd.read_csv(url, compression = "zip", encoding = "SHIFT_JIS")`.  
+You can specify http settings in detail depend on pandas.read_csv function (encoding, compression, and so on).
+like `df = pd.read_csv(url, compression = "zip", encoding = "SHIFT_JIS")`.
 https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html

--- a/integration-box/cuenote-import/README.md
+++ b/integration-box/cuenote-import/README.md
@@ -10,7 +10,7 @@ In this repository, there are two directory: `./XML-API` is for XML API, `./JSON
 ### Cuenote
 
 - You need to have a username and a password for Cuenote API.
-- IP addresses used by [Treasure Data Custom Script](https://support.treasuredata.com/hc/en-us/articles/360033974194-IP-Addresses-used-by-Custom-Scripts) must be allowed by the whitelist.
+- IP addresses used by Treasure Data Custom Script must be allowed by the whitelist.
 - For more information about preparation, please contact a representative or a support of YMIRLINK.
 
 ### Treasure Data
@@ -36,7 +36,7 @@ td wf secrets --project cuenote_import --set td.apikey td.apiserver td.database
 |variable|sample|description|
 |:----|:----|:----|
 |`td.apikey`|`000/1234567890abcde`|Treasure Data's API key with Master-Key permission|
-|`td.apiserver`|`https://api.treasuredata.com`|An endpoint of Treasure Data API. Use your [regional endpoint](https://support.treasuredata.com/hc/en-us/articles/360001474288-Sites-and-Endpoints).|
+|`td.apiserver`|`https://api.treasuredata.com`|An endpoint of Treasure Data API. Use your [regional endpoint](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1085143/Sites+and+Endpoints).|
 |`td.database`|`cuenote`|A name of database dedicated for Cuenote integration.|
 
 ### 3. Set variables for Cuenote API
@@ -69,7 +69,7 @@ Check if you see errors:
 
 ### XML API
 - A workflow `cuenote_import_master` retrieves all Job Info from Cuenote API. This contains a basic information about delivery settings.
-- `cuenote_import_master` stores Job Info, then request to Cuenote API to generate delivery logs and click logs. Then it saves `expid` into `queue` table. 
+- `cuenote_import_master` stores Job Info, then request to Cuenote API to generate delivery logs and click logs. Then it saves `expid` into `queue` table.
 - A workflow `cuenote_import_delivery_logs` checks a status of log generation and download logs if it is ready. Downloaded logs will be uploaded to each tables assigned to log type.
 
 ### JSON API

--- a/integration-box/datarobot/README.md
+++ b/integration-box/datarobot/README.md
@@ -1,27 +1,27 @@
 # DataRobot2TreasureData
-This digdag workflow creates a table on Treasure Data generated from DataRobot's prediction result using DataRobot Python client.   
-  
+This digdag workflow creates a table on Treasure Data generated from DataRobot's prediction result using DataRobot Python client.
+
 At first, DataRobot gets feature data from Treasure Data and create `pandas.DataFrame` including prediction result.
 Second, `pytd` creates a table on Treasure Data with the dataframe.
 
 ## Prerequisite
 - Supposes that you already have built a ML model and set Treasure Data as a data source on DataRobot.
-- Following parameters are necessary.  
+- Following parameters are necessary.
 
 | Variable | Description | Example |
 | -------- | ----------- | --------|
-| td.apikey | Master API Key for Treasure Data. [link](https://support.treasuredata.com/hc/en-us/articles/360000763288-Get-API-Keys) | `1234/abcdefghijklmnopqrstuvwxyz1234567890`|
+| td.apikey | Master API Key for Treasure Data. [link](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081428/Getting+Your+API+Keys) | `1234/abcdefghijklmnopqrstuvwxyz1234567890`|
 | td.database | Treasure Data's database name to export data. | `example_db` |
 | td.table | Treasure Data's table name to export data. | `example_table` |
 | td.sql | SQL to pass to Treasure Data's to retrieve a prediction data. | `select * from pred_data` |
 | dr.apikey | DataRobot's API Key. \*  | `ABcdEFGhIJk12MNoPqrS3uvW_xyz123`|
 | dr.username | Email address to log in Datarobot console | `example@yourcompany.com` |
-| dr.cloudkey | datarobot-key for DataRobot Cloud Prediction Server. \* | `e1234bc6-1aaa-98de-7f65-1234b5678ccc` | 
-| dr.prediction_host | Hostname/IP of DataRobot Prediction Server. \* | `prediction.datarobot.com` | 
-| dr.target | Target name of prediction. \* | `is_bad_loan` | 
-| dr.deployment_id | Deployment ID for DataRobot. \* | `5d3e76e931c473290afae6fd` | 
+| dr.cloudkey | datarobot-key for DataRobot Cloud Prediction Server. \* | `e1234bc6-1aaa-98de-7f65-1234b5678ccc` |
+| dr.prediction_host | Hostname/IP of DataRobot Prediction Server. \* | `prediction.datarobot.com` |
+| dr.target | Target name of prediction. \* | `is_bad_loan` |
+| dr.deployment_id | Deployment ID for DataRobot. \* | `5d3e76e931c473290afae6fd` |
 
-\* You can get these parameters from Deployments tab. 
+\* You can get these parameters from Deployments tab.
 https://app.datarobot.com/deployments/{deployment_id}/integrations
 
 ## Push the code and set variables
@@ -35,18 +35,18 @@ td wf secret --project datarobot_integration --set dr.cloudkey
 ```
 
 ## Result
-Prediction result are written into specified table like this.  
-<img src="./images/treasuredata.png" width="400px">  
+Prediction result are written into specified table like this.
+<img src="./images/treasuredata.png" width="400px">
 The table contains prediction result and features.
 
 ## Limitation
-DataRobot's Prediction API restricts the data size <= 50MB.  
+DataRobot's Prediction API restricts the data size <= 50MB.
 When predicting bigger data, you need to partition and predict for each parts.
 
 ## Further Reading
-- DataRobot API (You need to login DataRobot)  
+- DataRobot API (You need to login DataRobot)
 https://app.datarobot.com/docs/index.html
-- DataRobot Python Client  
+- DataRobot Python Client
 https://datarobot-public-api-client.readthedocs-hosted.com/en/v2.17.0/setup/getting_started.html
-- pytd  
+- pytd
 https://github.com/treasure-data/pytd

--- a/integration-box/mbed-os/README.md
+++ b/integration-box/mbed-os/README.md
@@ -10,7 +10,7 @@ This Box shows an example of ingesting device heap information to Treasure Data 
 
 ![mbed-td](./images/mbed-td.png)
 
-Depending on the functionalities of your device (i.e., sensors attached to your device) and code running on Mbed OS, we can collect various physical signals such as environmental conditions. 
+Depending on the functionalities of your device (i.e., sensors attached to your device) and code running on Mbed OS, we can collect various physical signals such as environmental conditions.
 
 ## Usage
 
@@ -18,7 +18,7 @@ Depending on the functionalities of your device (i.e., sensors attached to your 
 
 First and foremost, create `mbed_app.json` based on [`mbed_app.sample.json`](./mbed_app.sample.json), and set `td_apikey`, `td_database`, and `td_table` config values properly.
 
-This Box assumes [DISCO-F413ZH](https://os.mbed.com/platforms/ST-Discovery-F413H/) as an Mbed-enabled device, and we connect the board to the internet via its ISM43362 WiFi module; `SSID` and `PASSWORD` should be updated based on your WiFi environment. If you are using a different board or network drivers (e.g., Ethernet, Cellular), change the config setting in `mbed_app.json`. 
+This Box assumes [DISCO-F413ZH](https://os.mbed.com/platforms/ST-Discovery-F413H/) as an Mbed-enabled device, and we connect the board to the internet via its ISM43362 WiFi module; `SSID` and `PASSWORD` should be updated based on your WiFi environment. If you are using a different board or network drivers (e.g., Ethernet, Cellular), change the config setting in `mbed_app.json`.
 
 ### Installation
 
@@ -64,7 +64,7 @@ Compile the Box code, and enter to a serial terminal:
 mbed compile --target auto --toolchain GCC_ARM --flash --sterm
 ```
 
-The terminal tells you that device heap information is being collected and sent to [Treasure Data Postback API](https://support.treasuredata.com/hc/en-us/articles/360000675487-Postback-API):
+The terminal tells you that device heap information is being collected and sent to [Treasure Data Postback API](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083818/Postback+API):
 
 ```
 Treasure Boxes (Integration): Mbed OS + Treasure Data
@@ -94,10 +94,10 @@ This Box is a modified version of the following repository:
 
 Official documentation using Mbed Online Compiler is available at:
 
-- [Data Ingestion from Mbed OS (HTTP over Wi-Fi)](https://support.treasuredata.com/hc/en-us/articles/360012567313-Data-Ingestion-from-Mbed-OS-HTTP-over-Wi-Fi-)
+- [Data Ingestion from Mbed OS (HTTP over Wi-Fi)](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081510/Mbed+OS+for+Device+Tracking)
 
 Besides Postback API, there are alternative ways to ingest data from Mbed OS to Treasure Data; for example:
 
 - [Fluentd](https://github.com/BlackstoneEngineering/mbed-os-example-fluentlogger)
-- [Fluent Bit](https://support.treasuredata.com/hc/en-us/articles/360000691168-Data-Ingestion-from-Embedded-Apps-C-C-)
+- [Fluent Bit](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082746/Embedded+Apps+C+and+C+Import+Integration)
 - [MQTT Broker](../mqtt)

--- a/integration-box/mqtt/README.md
+++ b/integration-box/mqtt/README.md
@@ -1,6 +1,6 @@
 # Treasure Data MQTT Broker
 
-[Treasure Data MQTT broker](https://support.treasuredata.com/hc/en-us/articles/360034799633-Data-Ingestion-Using-the-Treasure-Data-MQTT-Broker-Experimental) allows you to ingest data through the [MQTT protocol](http://mqtt.org/). 
+[Treasure Data MQTT broker](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084422/MQTT+Broker+with+Treasure+Data) allows you to ingest data through the [MQTT protocol](http://mqtt.org/).
 
 Notice that our broker only accepts `publish` operation against a topic `mqtt-ingest`, and you cannot subscribe the topic. Plus, the MQTT broker currently requires client to be connected over SSL with a pair of given client certificate and RSA private key.
 

--- a/integration-box/pelion-device-management/README.md
+++ b/integration-box/pelion-device-management/README.md
@@ -6,7 +6,7 @@ PDM itself, however, does not store device data (i.e., resource values of your d
 
 ## Overview
 
-This Box demonstrates a simple way of pulling resource values from PDM to TD via [`ConnectAPI`](https://www.pelion.com/docs/device-management/current/service-api-references/device-management-connect.html) called by [PDM Python Client](https://github.com/ARMmbed/mbed-cloud-sdk-python) running on the [Treasure Workflow Custom Scripting](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084269/Custom%2BScripts) capability.
+This Box demonstrates a simple way of pulling resource values from PDM to TD via [`ConnectAPI`](https://www.pelion.com/docs/device-management/current/service-api-references/device-management-connect.html) called by [PDM Python Client](https://github.com/ARMmbed/mbed-cloud-sdk-python) running on the [Treasure Workflow Custom Scripting](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084247/Introduction+to+Custom+Scripts) capability.
 
 We assume your device has already been registered to PDM. For instance, if you are right after finishing [PDM IoT Connection Tutorial](https://os.mbed.com/guides/connect-device-to-pelion/), device and resource information can be listed as follows:
 

--- a/integration-box/pelion-device-management/README.md
+++ b/integration-box/pelion-device-management/README.md
@@ -1,12 +1,12 @@
 # Pulling Device Resource Values from Pelion Device Management to Treasure Data
 
-**[Pelion Device Management](https://www.pelion.com/iot-device-management/)** (PDM) is an IoT device management platform that accelerates your IoT project by providing a way to connect, secure, monitor and update massively deployed devices at scale and ease. 
+**[Pelion Device Management](https://www.pelion.com/iot-device-management/)** (PDM) is an IoT device management platform that accelerates your IoT project by providing a way to connect, secure, monitor and update massively deployed devices at scale and ease.
 
 PDM itself, however, does not store device data (i.e., resource values of your devices), and hence **[Pelion Data Management](https://www.arm.com/products/iot/pelion-iot-platform/data-management)** (Treasure Data; TD) becomes a place where your device data is securely stored in the cloud for analyzing historical data, integrating with the other Physical and Digital data sources, gaining deeper insights and making business outcomes.
 
 ## Overview
 
-This Box demonstrates a simple way of pulling resource values from PDM to TD via [`ConnectAPI`](https://www.pelion.com/docs/device-management/current/service-api-references/device-management-connect.html) called by [PDM Python Client](https://github.com/ARMmbed/mbed-cloud-sdk-python) running on the [Treasure Workflow Custom Scripting](https://support.treasuredata.com/hc/en-us/articles/360026713713-Introduction-to-Custom-Scripts) capability.
+This Box demonstrates a simple way of pulling resource values from PDM to TD via [`ConnectAPI`](https://www.pelion.com/docs/device-management/current/service-api-references/device-management-connect.html) called by [PDM Python Client](https://github.com/ARMmbed/mbed-cloud-sdk-python) running on the [Treasure Workflow Custom Scripting](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084269/Custom%2BScripts) capability.
 
 We assume your device has already been registered to PDM. For instance, if you are right after finishing [PDM IoT Connection Tutorial](https://os.mbed.com/guides/connect-device-to-pelion/), device and resource information can be listed as follows:
 
@@ -28,12 +28,12 @@ Next, push the workflow to TD:
 td wf push pelion_device
 ```
 
-Here, get your API key and endpoint from [PDM](https://preview.pelion.com/docs/device-management/current/integrate-web-app/api-keys.html) and [TD](https://support.treasuredata.com/hc/en-us/articles/360000763288-Get-API-Keys), and set them to the workflow secrets:
+Here, get your API key and endpoint from [PDM](https://preview.pelion.com/docs/device-management/current/integrate-web-app/api-keys.html) and [TD](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081428/Getting+Your+API+Keys), and set them to the workflow secrets:
 
 ```sh
 td wf secrets \
 	--project pelion_device \
-	--set td.apikey td.apiserver pdm.apikey pdm.host 
+	--set td.apikey td.apiserver pdm.apikey pdm.host
 ```
 
 |Variable|Description|Example|

--- a/integration-box/pelion-device-management/pelion_device.dig
+++ b/integration-box/pelion-device-management/pelion_device.dig
@@ -1,7 +1,7 @@
 timezone: UTC
 
 # See
-# https://support.treasuredata.com/hc/en-us/articles/360001262307-Scheduling-Workflows-in-the-CLI
+# https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081710/Scheduling+Workflows+from+the+Command+Line
 # for scheduling workflow
 schedule:
   hourly>: 00:00

--- a/integration-box/pyspark/README.md
+++ b/integration-box/pyspark/README.md
@@ -15,4 +15,4 @@ $ td wf start td-spark pyspark --session now
 
 ## Further Readings
 
-- [td-spark Official doc](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082513/Apache+Spark+Driver+td-spark+FAQs)
+- [td-spark Official doc](https://treasure-data.github.io/td-spark/)

--- a/integration-box/pyspark/README.md
+++ b/integration-box/pyspark/README.md
@@ -15,4 +15,4 @@ $ td wf start td-spark pyspark --session now
 
 ## Further Readings
 
-- [td-spark Official doc](https://support.treasuredata.com/hc/en-us/articles/360001487167-Apache-Spark-Driver-td-spark-FAQs)
+- [td-spark Official doc](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082513/Apache+Spark+Driver+td-spark+FAQs)

--- a/integration-box/rss/README.md
+++ b/integration-box/rss/README.md
@@ -1,4 +1,4 @@
-# Get RSS feed data and import it to a table 
+# Get RSS feed data and import it to a table
 This workflow gets RSS feed data from web sites you specified and import data to a table. RSS data usually includes contets of web articles. You can utilize those data by tokenize and keyword tagging to users with scores combined with user web activities, for example.
 
 ## How to use
@@ -14,7 +14,7 @@ $ td wf secrets --project rss_import --set td.apikey --set td.apiserver
 |Variable|Description|Example|
 |:---|:---|:---|
 |`td.apikey`|An API key to be used in the script. Access Type must be `Master Key`.|`1234/abcdefghijklmnopqrstuvwxyz1234567890`|
-|`td.apiserver`|TD's API endpoint starting with `https://`. See our [document](https://support.treasuredata.com/hc/en-us/articles/360001474288-Sites-and-Endpoints#Endpoints) for details.|`https://api.treasuredata.com`|
+|`td.apiserver`|TD's API endpoint starting with `https://`. See our [document](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1085143/Sites+and+Endpoints#Endpoints) for details.|`https://api.treasuredata.com`|
 
 ### Set RSS url list
 Set rss_url_list you want to get imported in [rss_import.dig](rss_import.dig) file.

--- a/integration-box/s3/s3.dig
+++ b/integration-box/s3/s3.dig
@@ -10,7 +10,7 @@ _export:
     image: "digdag/digdag-python:3.7"
   _env:
     # For secrets documentation,
-    # See https://support.treasuredata.com/hc/en-us/articles/360001266788-Workflows-Secrets-Management
+    # See https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
     S3_ACCESS_KEY_ID: ${secret:s3.access_key_id}
     S3_SECRET_ACCESS_KEY: ${secret:s3.secret_access_key}
 

--- a/integration-box/scorer-cloud/README.md
+++ b/integration-box/scorer-cloud/README.md
@@ -72,7 +72,7 @@ td wf secrets --project scorer \
               --set s3.secret_access_key=${S3_SECRET_ACCESS_KEY}
 ```
 
-When `schedule>` section of the `.dig` file is configured as `daily>: 00:00:00`, the workflow automatically pulls the data created by SCORER Cloud from S3 every day at midnight. 
+When `schedule>` section of the `.dig` file is configured as `daily>: 00:00:00`, the workflow automatically pulls the data created by SCORER Cloud from S3 every day at midnight.
 
 Verify if the workflow runs correctly:
 
@@ -82,7 +82,7 @@ td wf start scorer scorer --session now
 
 ## Sample Application: Counting Number of Unique Person
 
-Once the results are copied to Treasure Data, we can build various applications on top of that. 
+Once the results are copied to Treasure Data, we can build various applications on top of that.
 
 To give an example, for individual pair of estimated demographics, following query counts number of unique person in a video with 1-day time interval:
 
@@ -92,27 +92,27 @@ with people as (
     date_parse(datetime, '%Y-%m-%d %T.%f') as datetime,
     uid,
     json_parse(attributes) as attributes
-  from 
+  from
     sense_video
   where
     type = 1 -- pedestrian
     and confidence > 0.9
 )
-select 
-  json_extract_scalar(attributes, '$.Age') as age, 
+select
+  json_extract_scalar(attributes, '$.Age') as age,
   json_extract_scalar(attributes, '$.Gender') as gender,
   count(distinct uid) as num_unique_person_today
-from 
+from
   people
-where 
+where
   TD_INTERVAL(to_unixtime(datetime), '1d', 'JST')
   and cast(json_extract(attributes, '$.AgeConf') as double) > 0.9
   and cast(json_extract(attributes, '$.GenderConf') as double) > 0.9
-group by 
+group by
   1, 2
 ```
 
-See [documentation](https://support.treasuredata.com/hc/en-us/articles/360001450828-Supported-Presto-and-TD-Functions#TD_INTERVAL) to learn more about `TD_INTERVAL`.
+See [documentation](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083429/Supported+Presto+and+TD+Functions#TD_INTERVAL) to learn more about `TD_INTERVAL`.
 
 Output can be:
 

--- a/integration-box/swimos/README.md
+++ b/integration-box/swimos/README.md
@@ -12,7 +12,7 @@ This way, you can gain insights not only in real-time by Swim but also in a batc
 
 ## Usage
 
-[`patch-tutorial.diff`](./patch-tutorial.diff) adds code fragments to the definition of *Web Agent,* which indicates an interconnected, distributed object of Swim applications, in [swimos/tutorial](https://github.com/swimos/tutorial): 
+[`patch-tutorial.diff`](./patch-tutorial.diff) adds code fragments to the definition of *Web Agent,* which indicates an interconnected, distributed object of Swim applications, in [swimos/tutorial](https://github.com/swimos/tutorial):
 
 ```sh
 cd tutorial/server
@@ -20,7 +20,7 @@ git apply ../../patch-tutorial.diff
 # set values to TD_WRITE_KEY, TD_DATABASE, TD_TABLE variables
 ```
 
-By running the Swim application, a mock data source publishes random records (e.g., `{'foo': 62, 'bar': 126, 'baz': 174}`) to a Web Agent, and the agent passes the records to [Treasure Data Postback API](https://support.treasuredata.com/hc/en-us/articles/360000675487-Postback-API) along with setting value to the other [Lanes](https://developer.swim.ai/concepts/lanes/):
+By running the Swim application, a mock data source publishes random records (e.g., `{'foo': 62, 'bar': 126, 'baz': 174}`) to a Web Agent, and the agent passes the records to [Treasure Data Postback API](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083818/Postback+API) along with setting value to the other [Lanes](https://developer.swim.ai/concepts/lanes/):
 
 ```sh
 ./gradlew run

--- a/machine-learning-box/ml_tips/docs/more.md
+++ b/machine-learning-box/ml_tips/docs/more.md
@@ -32,20 +32,20 @@ Random sampling is a simple way to split data.
     # prepare.dig
     _export:
       train_sample_rate: 0.8
-    
+
     +shuffle:
       td>: queries/shuffle.sql
       engine: presto
       create_table: samples_shuffled
-    
+
     +split:
       _parallel: true
-    
+
       +train:
         td>: queries/split_train.sql
         engine: presto
         create_table: samples_train
-    
+
       +test:
         td>: queries/split_test.sql
         engine: presto
@@ -63,7 +63,7 @@ In shuffle.sql, we add a random float number distributed uniformly from 0.0 to 
 
 Presto doesn't have a way to use a random seed. If you want to split a reproducible way, use Hive instead.
 
-`rowid()` function assigns a unique id for each row. Although `select *` could include [v columns](https://support.treasuredata.com/hc/en-us/articles/360001266468-Schema-Management#Understanding%20the%20TD%20Default%20Schema%C2%A0), it's better to specify target columns, respectively.
+`rowid()` function assigns a unique id for each row. Although `select *` could include [v columns](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083743/Schema+Management#Understanding-the-TD-Default-Schema), it's better to specify target columns, respectively.
 
     -- Hive: queries/shuffle.sql
     select
@@ -99,20 +99,20 @@ The steps to apply stratified sampling is similar to random sampling. Here is an
     # prepare.dig
     _export:
       train_sample_rate: 0.8
-    
+
     +shuffle:
       td>: queries/shuffle.sql
       engine: presto
       create_table: samples_shuffled
-    
+
     +split:
       _parallel: true
-    
+
       +train:
         td>: queries/split_train.sql
         engine: presto
         create_table: samples_train
-    
+
       +test:
         td>: queries/split_test.sql
         engine: presto
@@ -204,7 +204,7 @@ Min-max scaling is used for normalization. The following workflow applies min-ma
         td>: queries/minmax_train.sql
         engine: presto
         store_last_results: true
-    
+
       +test:
         td>: queries/minmax_test.sql
         engine: presto
@@ -244,11 +244,11 @@ You can create a train/test table as follows:
 
     +preprocess:
       _parallel: true
-    
+
       +train:
         td>: queries/preprocess_train.sql
         create_table: train
-    
+
       +test:
         td>: queries/preprocess_test.sql
         create_table: test
@@ -287,7 +287,7 @@ You can [standardize](https://en.wikipedia.org/wiki/Standard_score) data by usin
         td>: queries/calc_stats.sql
         engine: presto
         store_last_results: true
-    
+
       +transform:
         td>: queries/transform.sql
         create_table: standardized_table
@@ -332,7 +332,7 @@ However, RandomForest classifier/regressor is an exception that accepts only an 
 The `feature_hashing` function enables you to convert string index to integer index as follows:
 
     select feature_hashing(array('aaa:1.0','aaa','bbb:2.0', '3:0.3'))
-    
+
     -- ["4063537:1.0","4063537","8459207:2.0", "4331412:0.3"]
 
 The original motivation for using the `feature_hashing` function is to restrict the size of the feature space. It also converts numerical values into other ones. For more detail of Feature Hashing, see [this document](https://en.wikipedia.org/wiki/Feature_hashing).
@@ -505,15 +505,15 @@ In this example, we assume you want to search for two hyperparameters: `eta0` an
 You can train and evaluate as shown in the following.
 
     _parallel: true
-    
+
     _do:
       _export:
         suffix: _${reg}_${eta0.toString().replace('.', '_')}
-    
+
       +train:
-        td>: queries/tarin_regressor.sql	
+        td>: queries/tarin_regressor.sql
         create_table: regressor${suffix}
-    
+
       +evaluate:
         td>: queries/evaluate_params.sql
         insert_into: accuracy_test
@@ -580,7 +580,7 @@ Now, you can find the best model by using the following workflow.
         engine: presto
         measure: rmse
         store_last_results: true
-    
+
       +save_model:
         td_ddl>:
         suffix: _${td.last_results.reg}_${td.last_results.eta0.toString().replace('.', '_')}
@@ -604,42 +604,42 @@ Here is the whole workflow for a grid search. This workflow and the queries can 
       for_each>:
         eta0: [5.0, 1.0, 0.5, 0.1, 0.05, 0.01, 0.001]
         reg: ['no', 'rda', 'l1', 'l2', 'elasticnet']
-    
+
       _parallel: true
-    
+
       _do:
         +train:
           td>: queries/train_regressor.sql
           suffix: _${reg}_${eta0.toString().replace('.', '_')}
           create_table: regressor${suffix}
-    
+
         +evaluate:
           td>: queries/evaluate_params.sql
           insert_into: accuracy_test
           suffix: _${reg}_${eta0.toString().replace('.', '_')}
-    
+
     +parsist_best:
       +choose_best:
         td>: queries/best_param.sql
         engine: presto
         measure: rmse
         store_last_results: true
-    
+
       +show_accuracy:
         echo>: "Best model reg: ${td.last_results.reg}, eta0: ${td.last_results.eta0} RMSE: ${td.last_results.rmse}, MAE: ${td.last_results.mae}"
-    
+
       +save_model:
         td_ddl>:
         suffix: _${td.last_results.reg}_${td.last_results.eta0.toString().replace('.', '_')}
         rename_tables: [{from: "regressor${suffix}", to: regressor_best}]
-    
+
       +clean_up:
         for_each>:
           eta0: [5.0, 1.0, 0.5, 0.1, 0.05, 0.01, 0.001]
           reg: ['no', 'rda', 'l1', 'l2', 'elasticnet']
-    
+
         _parallel: true
-    
+
         _do:
           +drop_table:
             td_ddl>:
@@ -656,19 +656,19 @@ Here is the whole workflow for a grid search. This workflow and the queries can 
       n_iter: 20 # Iteration number for parameter search
       eta0: [5.0, 1.0, 0.5, 0.1, 0.05, 0.01, 0.001]
       reg: ['no', 'rda', 'l1', 'l2', 'elasticnet']
-    
+
     +parameter_tuning:
       for_each>:
         param: ${param_list}
-    
+
       _parallel: true
-    
+
       _do:
         +train:
           td>: queries/train_regressor.sql
           suffix: _${param.reg}_${param.eta0.replace('.', '_')}
           create_table: regressor${suffix}
-    
+
         +evaluate:
           td>: queries/evaluate_params.sql
           insert_into: accuracy_test
@@ -679,17 +679,17 @@ The following Python script generates a parameter list. Before running this code
     # rand.py
     def rand_params(n_iter, eta0, reg):
         from sklearn.model_selection import ParameterSampler
-    
+
         param_dist = {"eta0": eta0, "reg": reg}
-    
+
         param_list = list(ParameterSampler(param_dist, n_iter=n_iter))
         try:
             import digdag
             digdag.env.store({"param_list": param_list})
-    
+
         except ImportError:
             pass
-    
+
         return True
 
 If you want to generate random numbers under certain distribution, you can use `scipy.stats`. You need to install scipy via `pip install scipy` as well.
@@ -698,19 +698,19 @@ If you want to generate random numbers under certain distribution, you can use `
     def rand_params(n_iter):
         from sklearn.model_selection import ParameterSampler
         from scipy.stats import randint as sp_randint
-    
+
         param_dist = {"max_depth": [3, None],
                   "max_features": sp_randint(1, 11),
                   "min_samples_split": sp_randint(2, 11),
                   "bootstrap": [True, False],
                   "criterion": ["gini", "entropy"]}
-    
+
         param_list = list(ParameterSampler(param_dist, n_iter=n_iter))
         try:
             import digdag
             digdag.env.store({"param_list": param_list})
-    
+
         except ImportError:
             pass
-    
+
         return True

--- a/machine-learning-box/recommendation/README.md
+++ b/machine-learning-box/recommendation/README.md
@@ -31,14 +31,14 @@ $ td wf push recommendation # push workflow to TD
 $ td wf start recommendation recommend --session now
 ```
 
-* [recommend.dig](recommend.dig) - TD workflow script for top-k item recommendation using [Matrix Factorization](https://docs.treasuredata.com/articles/hivemall-movielens20m-mf)
+* [recommend.dig](recommend.dig) - TD workflow script for top-k item recommendation using [Matrix Factorization](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081696/MovieLens+20M+Rating+Prediction+by+Matrix+Factorization)
 * [config/params.yml](config/params.yml) - defines configurable parameters for the recommendation workflow such as `k` of top-k. By the default, the workflow recommends top-10 items for each user.
 
 [<img src="docs/img/capture.png" alt="capture" max_height=300 />](http://showterm.io/31b8df49efcfbc2bfc5ef#fast)
 
 ### Workflow with PySpark
 
-You also can try [Spark.ml collaborative filtering](https://spark.apache.org/docs/2.4.0/ml-collaborative-filtering.html) recommendation for top-k item recommendation. Ensure both [Python Custom Scripting](https://support.treasuredata.com/hc/en-us/articles/360026713713-Introduction-to-Custom-Scripts) and [td-spark](https://support.treasuredata.com/hc/en-us/articles/360000716627-Apache-Spark-Driver-td-spark-Release-Notes) enabled.
+You also can try [Spark.ml collaborative filtering](https://spark.apache.org/docs/2.4.0/ml-collaborative-filtering.html) recommendation for top-k item recommendation. Ensure both [Python Custom Scripting](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084269/Custom%2BScripts) and [td-spark](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082542/Using+Apache+Spark+Driver+TD-Spark+in+your+Spark+Environment) enabled.
 
 ```sh
 $ ./data.sh
@@ -48,7 +48,7 @@ $ td wf secrets --project recommendation --set td.apikey --set td.apiserver
 $ td wf start recommendation recommend_spark --session now
 ```
 
-* [recommend_spark.dig](recommend_spark.dig) - TD workflow script for top-k item recommendation using [Matrix Factorization](https://docs.treasuredata.com/articles/hivemall-movielens20m-mf)
+* [recommend_spark.dig](recommend_spark.dig) - TD workflow script for top-k item recommendation using [Matrix Factorization](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081696/MovieLens+20M+Rating+Prediction+by+Matrix+Factorization)
 * [recommend.py](py_scripts/recommend.py) - Python script for PySpark ALS recommendation.
 * [config/params.yml](config/params.yml) - Configurable parameters for the recommendation workflow. This workflow uses `k` of top-k and `target` as database name. By the default, the workflow recommends top-10 items for each user.
 

--- a/machine-learning-box/recommendation/README.md
+++ b/machine-learning-box/recommendation/README.md
@@ -38,7 +38,7 @@ $ td wf start recommendation recommend --session now
 
 ### Workflow with PySpark
 
-You also can try [Spark.ml collaborative filtering](https://spark.apache.org/docs/2.4.0/ml-collaborative-filtering.html) recommendation for top-k item recommendation. Ensure both [Python Custom Scripting](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084269/Custom%2BScripts) and [td-spark](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082542/Using+Apache+Spark+Driver+TD-Spark+in+your+Spark+Environment) enabled.
+You also can try [Spark.ml collaborative filtering](https://spark.apache.org/docs/2.4.0/ml-collaborative-filtering.html) recommendation for top-k item recommendation. Ensure both [Python Custom Scripting](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084247/Introduction+to+Custom+Scripts) and [td-spark](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082542/Using+Apache+Spark+Driver+TD-Spark+in+your+Spark+Environment) enabled.
 
 ```sh
 $ ./data.sh

--- a/scenarios/compare_last_results/README.md
+++ b/scenarios/compare_last_results/README.md
@@ -13,7 +13,7 @@ The `store_last_results` can store the first 1 row of the query results to ${td.
 
 In this scenario, some workflow operators are used. Please refer to the documentation for each operator.
 
- - `td>: operator`: [td>: Running Treasure Data Query](https://docs.treasuredata.com/articles/workflows)
+ - `td>: operator`: [td>: Running Treasure Data Query](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084693/Reference+for+Treasure+Data+Operators#td%3E:)
  - `for_each>: operator`: [for_each>: Repeat tasks for values](http://docs.digdag.io/operators/for_each.html)
  - `if>: operator`: [if>: Conditional execution](http://docs.digdag.io/operators/if.html)
 

--- a/scenarios/custom_notifications/mail_notification/README.md
+++ b/scenarios/custom_notifications/mail_notification/README.md
@@ -11,9 +11,9 @@ By default the notification on a workflow failure will only go to the owner of t
 
 In this scenario, some workflow operators are used. Please refer to the documentation for each operator.
 
- - `td>: operator`: [td>: Running Treasure Data Query](http://docs.digdag.io/operators/td.html)
- - `mail>: operator`: [mail>: Sending email](http://docs.digdag.io/operators/mail.html)
- - `_error: task`: [_error:](http://docs.digdag.io/concepts.html?highlight=_error#dynamic-task-generation-and-check-error-tasks)
+ - `td>: operator`: [td>: Running Treasure Data Query](https://docs.digdag.io/operators/td.html)
+ - `mail>: operator`: [mail>: Sending email](https://docs.digdag.io/operators/mail.html)
+ - `_error: task`: [_error:](https://docs.digdag.io/concepts.html?highlight=_error#dynamic-task-generation-and-check-error-tasks)
 
 # How to use
 

--- a/scenarios/custom_notifications/slack_notification/README.md
+++ b/scenarios/custom_notifications/slack_notification/README.md
@@ -2,7 +2,7 @@
 
 ## Scenario
 
-By default the notification on a workflow failure will only go to the owner of the workflow. The purpose of this scenario is to illustrate how to send a notification to a slack channel when a workflow encounters an error. 
+By default the notification on a workflow failure will only go to the owner of the workflow. The purpose of this scenario is to illustrate how to send a notification to a slack channel when a workflow encounters an error.
 
 *Steps*
 1. Run an incorrect query that results in a workflow failure.
@@ -11,9 +11,9 @@ By default the notification on a workflow failure will only go to the owner of t
 
 In this scenario, some workflow operators are used. Please refer to the documentation for each operator.
 
- - `td>: operator`: [td>: Running Treasure Data Query](http://docs.digdag.io/operators/td.html)
- - `http>: operator`: [http>: Making HTTP requests](http://docs.digdag.io/operators/http.html)
- - `_error: task`: [_error:](http://docs.digdag.io/concepts.html?highlight=_error#dynamic-task-generation-and-check-error-tasks)
+ - `td>: operator`: [td>: Running Treasure Data Query](https://docs.digdag.io/operators/td.html)
+ - `http>: operator`: [http>: Making HTTP requests](https://docs.digdag.io/operators/http.html)
+ - `_error: task`: [_error:](https://docs.digdag.io/concepts.html?highlight=_error#dynamic-task-generation-and-check-error-tasks)
 
 # How to use
 

--- a/scenarios/expand_json_s3/config/load.yml
+++ b/scenarios/expand_json_s3/config/load.yml
@@ -1,6 +1,6 @@
 # For more advanced config options, please check these URLs.
-# @see https://support.treasuredata.com/hc/en-us/articles/360001405608-Amazon-S3-Import
-# @see https://support.treasuredata.com/hc/en-us/articles/360001405947-expand-json-filter-plugin-for-Data-Connector
+# @see https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082523/Amazon+S3+Import+Integration
+# @see https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083538/expand+json+Filter+Function
 # @see https://github.com/embulk/embulk-input-s3
 ---
 in:
@@ -17,7 +17,7 @@ filters:
 - type: expand_json
   json_column_name: record
   root: "$."
-  # if true, workflow will fail when this filter gets invalid data format. 
+  # if true, workflow will fail when this filter gets invalid data format.
   stop_on_invalid_record: false
   expanded_columns:
     - {name: "id", type: long}
@@ -27,7 +27,7 @@ filters:
     - {name: "email.secondary", type: string}
 # time column is set to workflow session time
 - type: add_time
-  to_column: 
+  to_column:
     name: time
     type: timestamp
   from_value:

--- a/scenarios/get_wf_runnning_status/README.MD
+++ b/scenarios/get_wf_runnning_status/README.MD
@@ -6,11 +6,11 @@
 To get running status of another workflow
 
 ## Regarding api_host
-"api_host" in get_wf_running_status.dig is up to your account's site.  
+"api_host" in get_wf_running_status.dig is up to your account's site.
 You have to change it if your account's site is located in EU or Tokyo.
 
-Please refer to the doc for more details.  
-[https://support.treasuredata.com/hc/en-us/articles/360001474288-Sites-and-Endpoints](https://support.treasuredata.com/hc/en-us/articles/360001474288-Sites-and-Endpoints)
+Please refer to the doc for more details.
+https://tddocs.atlassian.net/wiki/spaces/PD/pages/1085143/Sites+and+Endpoints
 
 # How to Run
 First, upload the project.

--- a/scenarios/ignore_failure/README.md
+++ b/scenarios/ignore_failure/README.md
@@ -11,8 +11,8 @@ The purpose of this scenario is to make the workflow succeed regardless of wheth
 *Requirement*
 Digdag has 2 types of operators to execute another dig. The `ignore_failure` parameter is supported by `require>` operator only. So you have to use `require>` operator if you want to ignore failure.
 
- - `td>: operator`: [td>: Running Treasure Data Query](http://docs.digdag.io/operators/td.html)
- - `require>: [require>: Depends on another workflow](http://docs.digdag.io/operators/require.html)
+ - `td>: operator`: [td>: Running Treasure Data Query](https://docs.digdag.io/operators/td.html)
+ - `require>: [require>: Depends on another workflow](https://docs.digdag.io/operators/require.html)
 
 # How to Run for Server/Client Mode
 

--- a/scenarios/intermediate_table/README.md
+++ b/scenarios/intermediate_table/README.md
@@ -12,7 +12,7 @@ Steps 2 and 3 can be made into a Treasure Workflow which enables you to define r
 
 You can read additional information:
 1. [Efficiently Analyze Infinitely Growing Data with Incremental Queries](https://blog.treasuredata.com/blog/2017/07/25/analyze-infinitely-growing-data-incremental-queries/)
-2. [Treasure Workflow Docs](https://docs.treasuredata.com/articles/workflows)
+2. [Treasure Workflow Docs](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081518/Workflow+Reference)
 
 ## Scenario
 
@@ -32,7 +32,7 @@ In this scenario, some workflow operators are used. Please refer to the document
 The initial load file ([initial_task.dig](initial_task.dig)) run the first query that creates the intermediate table that subsequent queries will run against.
 
 ## Daily Run
-The daily run file is scheduled to run every day at 1:00. It performs two tasks. 
+The daily run file is scheduled to run every day at 1:00. It performs two tasks.
 	- It updates the intermediate table created by initial_task.dig.
 	- Run the query in the analytics.sql file against the intermediate table.
 
@@ -50,6 +50,6 @@ You can trigger the session manually to watch it execute.
 
 
 # Next Step
-This is a simple example using only one intermediate table and just one subsequent query. However, you can use workflows and intermediate tables to chain together many sequential queries that normally would be one very large query that consumed a lot of time and resources. Consider workflows and intermediate tables as a possible solution for your large, time and resource consuming jobs. Feel free to contact support for assistance with reviewing any queries to see if workflows can improve performance.  
+This is a simple example using only one intermediate table and just one subsequent query. However, you can use workflows and intermediate tables to chain together many sequential queries that normally would be one very large query that consumed a lot of time and resources. Consider workflows and intermediate tables as a possible solution for your large, time and resource consuming jobs. Feel free to contact support for assistance with reviewing any queries to see if workflows can improve performance.
 
 If you have any questions, please contact to support@treasuredata.com.

--- a/scenarios/kill_wf_attempt/README.md
+++ b/scenarios/kill_wf_attempt/README.md
@@ -9,11 +9,11 @@ To kill the attempt automatically if the attempt violates sla.
 - python custom scripting is enabled on your account
 
 ## Regarding baseurl
-"baseurl" in kill_wf_attempt.dig is up to your account's site.  
-You have to change baseurl if your account's site is EU or Tokyo.
+"baseurl" in kill_wf_attempt.dig is up to your account's site.
+You have to change baseurl if your account's site is EU, Tokyo.
 
-Please refer to the doc for more details.  
-[https://support.treasuredata.com/hc/en-us/articles/360001474288](https://support.treasuredata.com/hc/en-us/articles/360001474288)
+Please refer to the doc for more details.
+https://tddocs.atlassian.net/wiki/spaces/PD/pages/1085143/Sites+and+Endpoints
 
 # How to Run
 First, upload the project.

--- a/scenarios/result_export/README.md
+++ b/scenarios/result_export/README.md
@@ -1,5 +1,5 @@
 # Workflow: export_result
-This example shows how use result_export API in Treasure Data workflow. 
+This example shows how use result_export API in Treasure Data workflow.
 You can export result to Your S3 & Tableau without running the same query.
 
 ###  Note: **This is experimental usage.**
@@ -23,11 +23,11 @@ $ td wf secret --project export_result_parallel --set td.apikey
 $ td wf secret --project export_result_parallel --set http.authorization
 ```
 
-Note: http.authorization is used as header in your API request. 
+Note: http.authorization is used as header in your API request.
 You must http.authorization like this : ```TD1 <Your APIKey>```
 
 For detail, please refer to the below page.
-https://support.treasuredata.com/hc/en-us/articles/
+https://tddocs.atlassian.net/wiki/spaces/PD/overview
 
 
 Third, please set your other services' credentials by ```td wf secrets``` command.
@@ -42,7 +42,7 @@ $ td wf secret --project export_result_parallel --set @credential.yml
 ```
 
 For detail, please refer to below page.
-https://support.treasuredata.com/hc/en-us/articles/360001266788-Workflows-Secrets-Management#L5
+https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
 
 Finally, you can trigger the session manually.
 

--- a/scenarios/result_export/export_result_TD/README.md
+++ b/scenarios/result_export/export_result_TD/README.md
@@ -1,5 +1,5 @@
 # Workflow: export_result to TD
-This example shows how use result_export API in Treasure Data workflow. 
+This example shows how use result_export API in Treasure Data workflow.
 You can export result to Another Treasure Data Account without running the same query.
 
 ## Scenario
@@ -21,11 +21,11 @@ $ td wf secret --project export_result_td --set td.apikey
 $ td wf secret --project export_result_td --set http.authorization
 ```
 
-Note: http.authorization is used as header in your API request. 
+Note: http.authorization is used as header in your API request.
 You must http.authorization like this : ```TD1 <Your APIKey>```
 
 For detail, please refer to the below page.
-https://support.treasuredata.com/hc/en-us/articles/
+https://tddocs.atlassian.net/wiki/spaces/PD/overview
 
 
 Third, please set your other services' credentials by ```td wf secrets``` command.
@@ -38,7 +38,7 @@ $ td wf secret --project export_result_td --set tdTable // Tabale
 ```
 
 For detail, please refer to below page.
-https://support.treasuredata.com/hc/en-us/articles/360001266788-Workflows-Secrets-Management#L5
+https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
 
 Finally, you can trigger the session manually.
 

--- a/scenarios/result_export/export_result_ftp/README.md
+++ b/scenarios/result_export/export_result_ftp/README.md
@@ -1,5 +1,5 @@
 # Workflow: export_result
-This example shows how use result_export API in Treasure Data workflow. 
+This example shows how use result_export API in Treasure Data workflow.
 You can export result to Your FTP serber without running the same query.
 
 ## Scenario
@@ -21,11 +21,11 @@ $ td wf secret --project export_result_ftp --set td.apikey
 $ td wf secret --project export_result_ftp --set http.authorization
 ```
 
-Note: http.authorization is used as header in your API request. 
+Note: http.authorization is used as header in your API request.
 You must http.authorization like this : ```TD1 <Your APIKey>```
 
 For detail, please refer to the below page.
-https://support.treasuredata.com/hc/en-us/articles/
+https://tddocs.atlassian.net/wiki/spaces/PD/overview
 
 
 Third, please set your other services' credentials by ```td wf secrets``` command.
@@ -39,7 +39,7 @@ $ td wf secret --project export_result_ftp --set ftpPathPrefix // FTP pathprefix
 ```
 
 For detail, please refer to below page.
-https://support.treasuredata.com/hc/en-us/articles/360001266788-Workflows-Secrets-Management#L5
+https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
 
 Finally, you can trigger the session manually.
 

--- a/scenarios/result_export/export_result_mongodb/README.md
+++ b/scenarios/result_export/export_result_mongodb/README.md
@@ -21,11 +21,11 @@ $ td wf secret --project export_result_mongodb --set td.apikey
 $ td wf secret --project export_result_mongodb --set http.authorization
 ```
 
-Note: http.authorization is used as header in your API request. 
+Note: http.authorization is used as header in your API request.
 You must http.authorization like this : ```TD1 <Your APIKey>```
 
 For detail, please refer to the below page.
-https://support.treasuredata.com/hc/en-us/articles/
+https://tddocs.atlassian.net/wiki/spaces/PD/overview
 
 
 Third, please set your other services' credentials by ```td wf secrets``` command.
@@ -40,7 +40,7 @@ $ td wf secret --project export_result_mongodb --set mongodbTable // RedShift Ta
 ```
 
 For detail, please refer to below page.
-https://support.treasuredata.com/hc/en-us/articles/360001266788-Workflows-Secrets-Management#L5
+https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
 
 Finally, you can trigger the session manually.
 

--- a/scenarios/result_export/export_result_mysql/README.md
+++ b/scenarios/result_export/export_result_mysql/README.md
@@ -1,5 +1,5 @@
 # Workflow: export_result
-This example shows how use result_export API in Treasure Data workflow. 
+This example shows how use result_export API in Treasure Data workflow.
 You can export result to Your MySQL without running the same query.
 
 ## Scenario
@@ -21,11 +21,11 @@ $ td wf secret --project export_result_mysql --set td.apikey
 $ td wf secret --project export_result_mysql --set http.authorization
 ```
 
-Note: http.authorization is used as header in your API request. 
+Note: http.authorization is used as header in your API request.
 You must http.authorization like this : ```TD1 <Your APIKey>```
 
 For detail, please refer to the below page.
-https://support.treasuredata.com/hc/en-us/articles/
+https://tddocs.atlassian.net/wiki/spaces/PD/overview
 
 
 Third, please set your other services' credentials by ```td wf secrets``` command.
@@ -40,7 +40,7 @@ $ td wf secret --project export_result_mysql --set mysqlTable // MySQL Table
 ```
 
 For detail, please refer to below page.
-https://support.treasuredata.com/hc/en-us/articles/360001266788-Workflows-Secrets-Management#L5
+https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
 
 Finally, you can trigger the session manually.
 

--- a/scenarios/result_export/export_result_postgresql/README.md
+++ b/scenarios/result_export/export_result_postgresql/README.md
@@ -1,5 +1,5 @@
 # Workflow: export_result
-This example shows how use result_export API in Treasure Data workflow. 
+This example shows how use result_export API in Treasure Data workflow.
 You can export result to Your PostgreSQL without running the same query.
 
 ## Scenario
@@ -21,11 +21,11 @@ $ td wf secret --project export_result_postgresql --set td.apikey
 $ td wf secret --project export_result_postgresql --set http.authorization
 ```
 
-Note: http.authorization is used as header in your API request. 
+Note: http.authorization is used as header in your API request.
 You must http.authorization like this : ```TD1 <Your APIKey>```
 
 For detail, please refer to the below page.
-https://support.treasuredata.com/hc/en-us/articles/
+https://tddocs.atlassian.net/wiki/spaces/PD/overview
 
 
 Third, please set your other services' credentials by ```td wf secrets``` command.
@@ -40,7 +40,7 @@ $ td wf secret --project export_result_postgresql --set postgreTable // PostgreS
 ```
 
 For detail, please refer to below page.
-https://support.treasuredata.com/hc/en-us/articles/360001266788-Workflows-Secrets-Management#L5
+https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
 
 Finally, you can trigger the session manually.
 

--- a/scenarios/result_export/export_result_redshift/README.md
+++ b/scenarios/result_export/export_result_redshift/README.md
@@ -1,5 +1,5 @@
 # Workflow: export_result
-This example shows how use result_export API in Treasure Data workflow. 
+This example shows how use result_export API in Treasure Data workflow.
 You can export result to Your RedShift without running the same query.
 
 ## Scenario
@@ -21,11 +21,11 @@ $ td wf secret --project export_result_redshift --set td.apikey
 $ td wf secret --project export_result_redshift --set http.authorization
 ```
 
-Note: http.authorization is used as header in your API request. 
+Note: http.authorization is used as header in your API request.
 You must http.authorization like this : ```TD1 <Your APIKey>```
 
 For detail, please refer to the below page.
-https://support.treasuredata.com/hc/en-us/articles/
+https://tddocs.atlassian.net/wiki/spaces/PD/overview
 
 
 Third, please set your other services' credentials by ```td wf secrets``` command.
@@ -40,7 +40,7 @@ $ td wf secret --project export_result_redshift --set redshiftTable // RedShift 
 ```
 
 For detail, please refer to below page.
-https://support.treasuredata.com/hc/en-us/articles/360001266788-Workflows-Secrets-Management#L5
+https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
 
 Finally, you can trigger the session manually.
 

--- a/scenarios/result_export/export_result_s3/README.md
+++ b/scenarios/result_export/export_result_s3/README.md
@@ -1,5 +1,5 @@
 # Workflow: export_result
-This example shows how use result_export API in Treasure Data workflow. 
+This example shows how use result_export API in Treasure Data workflow.
 You can export result to Your S3 without running the same query.
 
 ## Scenario
@@ -21,11 +21,11 @@ $ td wf secret --project export_result_s3 --set td.apikey
 $ td wf secret --project export_result_example --set http.authorization
 ```
 
-Note: http.authorization is used as header in your API request. 
+Note: http.authorization is used as header in your API request.
 You must http.authorization like this : ```TD1 <Your APIKey>```
 
 For detail, please refer to the below page.
-https://support.treasuredata.com/hc/en-us/articles/
+https://tddocs.atlassian.net/wiki/spaces/PD/overview
 
 
 Third, please set your other services' credentials by ```td wf secrets``` command.
@@ -40,7 +40,7 @@ $ td wf secret --project export_result_example --set aws.s3.filepath
 
 
 For detail, please refer to below page.
-https://support.treasuredata.com/hc/en-us/articles/360001266788-Workflows-Secrets-Management#L5
+https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
 
 Finally, you can trigger the session manually.
 

--- a/scenarios/result_export/export_result_tableau/README.md
+++ b/scenarios/result_export/export_result_tableau/README.md
@@ -22,11 +22,11 @@ $ td wf secret --project export_result_tableau --set td.apikey
 $ td wf secret --project export_result_tableau --set http.authorization
 ```
 
-Note: http.authorization is used as header in your API request. 
+Note: http.authorization is used as header in your API request.
 You must http.authorization like this : ```TD1 <Your APIKey>```
 
 For detail, please refer to the below page.
-https://support.treasuredata.com/hc/en-us/articles/
+https://tddocs.atlassian.net/wiki/spaces/PD/overview
 
 
 Third, please set your other services' credentials by ```td wf secrets``` command.
@@ -41,7 +41,7 @@ $ td wf secret --project export_result_tableau --set tableauProject // Tabluau P
 ```
 
 For detail, please refer to below page.
-https://support.treasuredata.com/hc/en-us/articles/360001266788-Workflows-Secrets-Management#L5
+https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
 
 Finally, you can trigger the session manually.
 

--- a/scenarios/run_token_api_after_master_segment/README.md
+++ b/scenarios/run_token_api_after_master_segment/README.md
@@ -4,14 +4,14 @@
 
 There is a scenario which you want to kick certain workflow after the master segments finishes.
 This workflow checks if there is running master segment workflow or not. After finishing the master segment workflow, it will start Profile API refresh workflow.
- 
+
 
 ## Regarding api_host
-"api_host" in get_wf_running_status.dig is up to your account's site.  
+"api_host" in get_wf_running_status.dig is up to your account's site.
 You have to change it if your account's site is located in EU or Tokyo.
 
-Please refer to the doc for more details.  
-[https://support.treasuredata.com/hc/en-us/articles/360001474288-Sites-and-Endpoints](https://support.treasuredata.com/hc/en-us/articles/360001474288-Sites-and-Endpoints)
+Please refer to the doc for more details.
+https://tddocs.atlassian.net/wiki/spaces/PD/pages/1085143/Sites+and+Endpoints
 
 # How to Run
 First, upload the project.

--- a/scenarios/sequential_queries/README.md
+++ b/scenarios/sequential_queries/README.md
@@ -10,13 +10,13 @@ The purpose of this scenario is to get monthly ranking of access users per day. 
 *Steps*
 1. Clear the aggregated table.
 2. Run the queries to insert top 10 users per day to aggregated table.
-3. Run the query to analyze top 10 users of the month. 
+3. Run the query to analyze top 10 users of the month.
 
 In this scenario, some workflow operators are used. Please refer to the documentation for each operator.
 
- - `td>: operator`: [td>: Running Treasure Data Query](http://docs.digdag.io/operators/td.html)
- - `td_ddl: operator`: [td_ddl: Treasure Data operations](http://docs.digdag.io/operators/td_ddl.html)
- - `loop>: operator`: [loop>: Repeat tasks](http://docs.digdag.io/operators/loop.html)
+ - `td>: operator`: [td>: Running Treasure Data Query](https://docs.digdag.io/operators/td.html)
+ - `td_ddl: operator`: [td_ddl: Treasure Data operations](https://docs.digdag.io/operators/td_ddl.html)
+ - `loop>: operator`: [loop>: Repeat tasks](https://docs.digdag.io/operators/loop.html)
 
 # How to Run for Server/Client Mode
 

--- a/td/bigquery/README.md
+++ b/td/bigquery/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to BigQuery)
 
-This example workflow ingests data using [Treasure Data's Writing Job Results into Google BigQuery](https://docs.treasuredata.com/articles/result-into-google-bigquery) with [td](http://docs.digdag.io/operators/td.html) operator.
+This example workflow ingests data using [Treasure Data's Writing Job Results into Google BigQuery](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081809/Google+BigQuery+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
@@ -19,7 +19,7 @@ First, please upload your workflow project by `td wf push` command.
     # Upload
     $ td wf push td_bigquery
 
-If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
+If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](https://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
     $ td wf secrets --project td_bigquery --set key

--- a/td/box/README.md
+++ b/td/box/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to Data Tanks)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Writing Job Results into BOX](https://support.treasuredata.com/hc/en-us/articles/360010338114-Box-Export) with [td](http://docs.digdag.io/operators/td.html) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Writing Job Results into BOX](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083770/Box+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # How to Run
 

--- a/td/dbm/README.md
+++ b/td/dbm/README.md
@@ -1,6 +1,6 @@
 # Workflow: Result Output to DoubleClick Bid Manager
 
-This example workflow ingests data using [Writing Job Results into Google DoubleClick Bid Manager on the DoubleClick Data Platform](https://support.treasuredata.com/hc/en-us/articles/360001286367-Writing-Job-Results-into-Google-DoubleClick-Bid-Manager-on-the-DoubleClick-Data-Platform) with [td](http://docs.digdag.io/operators/td.html) operator.
+This example workflow ingests data using [Writing Job Results into Google DoubleClick Bid Manager on the DoubleClick Data Platform](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082604/Google+DoubleClick+Bid+Manager+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
@@ -37,7 +37,7 @@ Available parameters for `result_settings` are here.
 - cookie_column_header: (string, required)
 - membership_lifespan: (int, optional)
 
-For more details, please see [Treasure Data documentation](https://support.treasuredata.com/hc/en-us/articles/360001286367-Writing-Job-Results-into-Google-DoubleClick-Bid-Manager-on-the-DoubleClick-Data-Platform)
+For more details, please see [Treasure Data documentation](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082604/Google+DoubleClick+Bid+Manager+Export+Integration)
 
 # Next Step
 

--- a/td/facebook_custom_audience/README.md
+++ b/td/facebook_custom_audience/README.md
@@ -1,10 +1,10 @@
 # Workflow: td example (Result Output to Facebook Custom Audience)
 
-This example workflow outputs data to a Facebook custom audience using [Writing Job Results into Facebook Custom Audience](https://support.treasuredata.com/hc/en-us/articles/360001288928-Writing-Job-Results-into-Facebook-Custom-Audience) with [td](http://docs.digdag.io/operators/td.html) operator.
+This example workflow outputs data to a Facebook custom audience using [Writing Job Results into Facebook Custom Audience](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083108/Facebook+Custom+Audience+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
-In order to register your credential in Treasure Data, please create connection by following the instructions on this page [Writing Job Results into Facebook Custom Audience](https://support.treasuredata.com/hc/en-us/articles/360001288928-Writing-Job-Results-into-Facebook-Custom-Audience) 
+In order to register your credential in Treasure Data, please create connection by following the instructions on this page [Writing Job Results into Facebook Custom Audience](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083108/Facebook+Custom+Audience+Export+Integration)
 
 The connection name is used in the dig file.
 
@@ -15,7 +15,7 @@ First, please upload your workflow project by `td wf push` command.
     # Upload
     $ td wf push td_facebook_custom_audience
 
-If you want to mask any settings, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
+If you want to mask any settings, please set it by `td wf secrets` command. For more details, please see [digdag documentation](https://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
     $ td wf secrets --project td_facebook_custom_audience --set key
@@ -45,12 +45,12 @@ Available parameters for `result_settings` are here.
 - description: description of output Custom Audience (string, optional)
 - pre_hashed : Whether or not the data has already been hashed. If not, the plugin will automatically hash the data (boolean, default: false)
 - customer_file_source : Specify the source of the user information collected into this file (string, default: null, values: USER_PROVIDED_ONLY, PARTNER_PROVIDED_ONLY, BOTH_USER_AND_PARTNER_PROVIDED)
-- retryInitialWaitMsec: time to wait between retries (int, required, default: 60000). 
+- retryInitialWaitMsec: time to wait between retries (int, required, default: 60000).
 - retryLimit: Number of times to retry on failure (int, optional, default: 5)
 
 
-For more details, please see [Treasure Data documentation (GUI)](https://support.treasuredata.com/hc/en-us/articles/360001262227-Treasure-Workflow-Quick-Start-Tutorial-for-the-GUI)
-or [Treasure Data documentation(CLI)](https://support.treasuredata.com/hc/en-us/articles/360001262207-Treasure-Workflow-Quick-Start-Tutorial-for-the-CLI)
+For more details, please see [Treasure Data documentation (GUI)](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084846/Using+Workflow+from+TD+Console)
+or [Treasure Data documentation(CLI)](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083651/Treasure+Workflow+Quick+Start+using+TD+Toolbelt+in+a+CLI)
 
 # Next Step
 If you have any questions, please contact support@treasuredata.com.

--- a/td/gcs/README.md
+++ b/td/gcs/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to Google Cloud Storage)
 
-This example workflow ingests data using [Treasure Data's Writing Job Results into Google Cloud Storage](https://docs.treasuredata.com/articles/result-into-google-cloud-storage) with [td](http://docs.digdag.io/operators/td.html) operator.
+This example workflow ingests data using [Treasure Data's Writing Job Results into Google Cloud Storage](https://tddocs.atlassian.net/wiki/spaces/PD/pages/4949333/Google+Cloud+Storage+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
@@ -19,7 +19,7 @@ First, please upload your workflow project by `td wf push` command.
     # Upload
     $ td wf push td_gcs
 
-If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
+If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](https://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
     $ td wf secrets --project td_gcs --set key

--- a/td/gsheet/README.md
+++ b/td/gsheet/README.md
@@ -5,7 +5,7 @@ This example workflow exports TD job results into a Google Sheets with [td](http
 # Prerequisites
 
 You need to create a new Authentication for Google Sheets in advance.
-Please refer to the section '2. Account authentication' in the [Treasure Data Documentation](https://support.treasuredata.com/hc/en-us/articles/360009671913-Writing-Job-Results-to-Google-Sheets) in order to find the procedure.
+Please refer to the section '2. Account authentication' in the [Treasure Data Documentation](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081625/Google+Sheets+Export+Integration) in order to find the procedure.
 
 The connection name is used in the dig file.
 
@@ -17,7 +17,7 @@ First, please upload your workflow project by `td wf push` command.
     # Upload
     $ td wf push td_gsheet
 
-If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
+If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](https://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
     $ td wf secrets --project td_gsheet --set key
@@ -55,7 +55,7 @@ Available parameters for `result_settings` are here.
 
 **※You must choose to use either the *****spreadsheet_id***** OR *****spreadsheet_title.***** You cannot use both.**
 
-For more details, please see [Treasure Data documentation](https://support.treasuredata.com/hc/en-us/articles/360009671913-Writing-Job-Results-to-Google-Sheets)
+For more details, please see [Treasure Data documentation](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081625/Google+Sheets+Export+Integration)
 
 # Next Step
 

--- a/td/mailchimp/README.md
+++ b/td/mailchimp/README.md
@@ -2,7 +2,7 @@
 
 [Our blog post](https://blog.treasuredata.com/blog/2016/08/31/increase-customer-engagement-with-mailchimp/) describes an importance of customer engagement with Mailchimp and Treasure Data
 
-This example workflow gives you an overview and directions on how to build personalized email lists on Mailchimp using [Treasure Data's Result Output to Mailchimp](https://docs.treasuredata.com/articles/result-into-mailchimp) with [td](http://docs.digdag.io/operators/td.html) operator.
+This example workflow gives you an overview and directions on how to build personalized email lists on Mailchimp using [Treasure Data's Result Output to Mailchimp](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081611/Mailchimp+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 In order to register your credential in TreasureData, please create connection setting on [Connector UI](https://console.treasuredata.com/app/connections).
 
@@ -19,7 +19,7 @@ First, please upload your workflow project by `td wf push` command.
     # Upload
     $ td wf push mailchimp_export
 
-If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
+If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](https://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
     $ td wf secrets --project mailchimp_export --set key
@@ -56,7 +56,7 @@ Available parameters for `result_settings` are here.
 - retry_initial_wait_msec: (int, default 1000)
 - max_retry_wait_msec: (int, default 32000)
 
-For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/articles/result-into-mailchimp)
+For more details, please see [Treasure Data documentation](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081611/Mailchimp+Export+Integration)
 
 # Next Step
 

--- a/td/marketo/README.md
+++ b/td/marketo/README.md
@@ -1,11 +1,11 @@
 # Workflow: td example (Result Output to Marketo)
 
-This example workflow exports TD job results into Marketo [Treasure Data's Writing Job Results into Marketo](https://support.treasuredata.com/hc/en-us/articles/360001536087-Writing-Job-Results-into-Marketo) with [td](http://docs.digdag.io/operators/td.html) operator.
+This example workflow exports TD job results into Marketo [Treasure Data's Writing Job Results into Marketo](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081744/Marketo+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
 The Marketo connection name is required for use in the workflow file.
-Create a new Marketo Connection using [Create Connection](https://docs.treasuredata.com/articles/result-into-marketo#step-1-create-a-new-connection) or use your existing connection. 
+Create a new Marketo Connection using [Create Connection](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081744/Marketo+Export+Integration#Create-a-New-Connection) or use your existing connection.
 
 
 # How to Run
@@ -41,7 +41,7 @@ Available parameters for `result_settings` are here.
 - upload_chunk_size_in_bytes: Max upload chunk size in bytes (integer, optional)
 - batch_max_wait_msec: Batch max wait in milliseconds (integer, optional)
 
-For more details on Result output to Marketo, please see [Treasure Data documentation](https://support.treasuredata.com/hc/en-us/articles/360001536087-Writing-Job-Results-into-Marketo)
+For more details on Result output to Marketo, please see [Treasure Data documentation](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081744/Marketo+Export+Integration)
 
 # Next Step
 

--- a/td/tableau/README.md
+++ b/td/tableau/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to Tableau)
 
-This example workflow ingests data using [Tableau Server with Treasure Data](https://docs.treasuredata.com/articles/tableau-server) or [Tableau Online with Treasure Data](https://docs.treasuredata.com/articles/tableau-online) with [td](http://docs.digdag.io/operators/td.html) operator.
+This example workflow ingests data using [Tableau Server with Treasure Data](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082963/Tableau+Server+Export+Integration) or [Tableau Online with Treasure Data](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081683/Tableau+Online+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
@@ -21,7 +21,7 @@ First, please upload your workflow project by `td wf push` command.
     # Upload
     $ td wf push tableau
 
-If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
+If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](https://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
     $ td wf secrets --project tableau --set key

--- a/td/twitter_tailored_audience/README.md
+++ b/td/twitter_tailored_audience/README.md
@@ -1,10 +1,10 @@
 # Workflow: td example (Result Output to Twitter Tailored Audience)
 
-This example workflow outputs data to a twitter tailorerd audience using [Writing Job Results into your Twitter Tailored Audience](https://support.treasuredata.com/hc/en-us/articles/360001286587-Writing-Job-Results-To-Your-Twitter-Tailored-Audience) with [td](http://docs.digdag.io/operators/td.html) operator.
+This example workflow outputs data to a twitter tailorerd audience using [Writing Job Results into your Twitter Tailored Audience](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081589/Twitter+Tailored+Audience+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
-In order to register your credential in Treasure Data, please create connection by following the instructions on this page [Writing Job Results into your Twitter Tailored Audience](https://support.treasuredata.com/hc/en-us/articles/360001286587-Writing-Job-Results-To-Your-Twitter-Tailored-Audience) 
+In order to register your credential in Treasure Data, please create connection by following the instructions on this page [Writing Job Results into your Twitter Tailored Audience](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081589/Twitter+Tailored+Audience+Export+Integration)
 
 The connection name is used in the dig file.
 
@@ -15,7 +15,7 @@ First, please upload your workflow project by `td wf push` command.
     # Upload
     $ td wf push twitter_tailored_audience
 
-If you want to mask any settings, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
+If you want to mask any settings, please set it by `td wf secrets` command. For more details, please see [digdag documentation](https://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
     $ td wf secrets --project twitter_tailored_audience --set key
@@ -48,8 +48,8 @@ Available parameters for `result_settings` are here.
 - max_retry_wait_msec: Maximum time in milliseconds between retrying attempts. (int, optional, default: 320000)
 
 
-For more details, please see [Treasure Data documentation (GUI)](https://support.treasuredata.com/hc/en-us/articles/360001262227-Treasure-Workflow-Quick-Start-Tutorial-for-the-GUI)
-or [Treasure Data documentation(CLI)](https://support.treasuredata.com/hc/en-us/articles/360001262207-Treasure-Workflow-Quick-Start-Tutorial-for-the-CLI)
+For more details, please see [Treasure Data documentation (GUI)](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084846/Using+Workflow+from+TD+Console)
+or [Treasure Data documentation(CLI)](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083651/Treasure+Workflow+Quick+Start+using+TD+Toolbelt+in+a+CLI)
 
 # Next Step
 If you have any questions, please contact support@treasuredata.com.

--- a/td_load/azure_blob_storage/README.md
+++ b/td_load/azure_blob_storage/README.md
@@ -1,8 +1,8 @@
 # Workflow: td_load Example (Microsoft Azure Blob Storage)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Microsoft Azure Blob Storage](https://support.treasuredata.com/hc/en-us/articles/360001405648) with [td_load](http://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Microsoft Azure Blob Storage](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081764/Microsoft+Azure+Blob+Storage+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
-The workflow also uses [Secrets](https://docs.treasuredata.com/articles/workflows-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
+The workflow also uses [Secrets](https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line) feature, so that you don't have to include your datasource credentials to your workflow files.
 
 # How to Run
 
@@ -25,7 +25,7 @@ Now, you can trigger the session manually.
 
     # Run
     $ td wf start td_load_example daily_load --session now
-    
+
 # Next Step
 
 If you have any questions, please contact support@treasure-data.com.

--- a/td_load/azure_blob_storage/config/daily_load.yml
+++ b/td_load/azure_blob_storage/config/daily_load.yml
@@ -1,5 +1,5 @@
 # For more advanced config options, please check these URLs.
-# @see https://support.treasuredata.com/hc/en-us/articles/360001405648
+# @see https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081764/Microsoft+Azure+Blob+Storage+Import+Integration
 # @see https://github.com/embulk/embulk-input-azure_blob_storage
 ---
 in:

--- a/td_load/bigquery/README.md
+++ b/td_load/bigquery/README.md
@@ -1,5 +1,5 @@
 # Workflow: td_load example (Google BigQuery)
-This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Google BigQuery](https://support.treasuredata.com/hc/en-us/articles/360001647267-Data-Connector-for-Google-BigQuery) with [td_load](http://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Google BigQuery](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081348/Google+BigQuery+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
 # How to Run for Server Mode
 First, please upload the workflow. `bigquery` is the project name.

--- a/td_load/gcs/README.md
+++ b/td_load/gcs/README.md
@@ -1,8 +1,8 @@
 # Workflow: td_load example (Google Cloud Storage)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Google Cloud Storage](https://docs.treasuredata.com/articles/data-connector-google-cloud-storage) with [td_load](http://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Google Cloud Storage](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082555/Google+Cloud+Storage+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
-The workflow also uses [Secrets](https://docs.treasuredata.com/articles/workflows-secrets) feature, so that you don't have to include your database credentials to your workflow files.
+The workflow also uses [Secrets](https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line) feature, so that you don't have to include your database credentials to your workflow files.
 
 # Prerequisites (v0.9.21 or earlier)
 

--- a/tool-box/get-table-row-counts/README.md
+++ b/tool-box/get-table-row-counts/README.md
@@ -28,7 +28,7 @@ schedule:
 ```
 
 ### TD endpoint
-You need to modify td_endpoint setting in [get_row_count.dig](get_row_count.dig) file for your TD region accordingly. See our [document](https://support.treasuredata.com/hc/en-us/articles/360001474288-Sites-and-Endpoints#Endpoints) for details.
+You need to modify td_endpoint setting in [get_row_count.dig](get_row_count.dig) file for your TD region accordingly. See our [document](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1085143/Sites+and+Endpoints#Endpoints) for details.
 ```
     td_endpoint: "https://api.treasuredata.com/"
 ```

--- a/tool-box/get_cdp_segments/README.md
+++ b/tool-box/get_cdp_segments/README.md
@@ -1,6 +1,6 @@
-# Import Master Segment and Segment List 
-This workflow gets Master Segment and Segment List data via CDP-API and import data into a table. 
-These data include meta data of each Master Segment and Segments. 
+# Import Master Segment and Segment List
+This workflow gets Master Segment and Segment List data via CDP-API and import data into a table.
+These data include meta data of each Master Segment and Segments.
 
 ## How to use
 ### Push workflow and set secret
@@ -11,15 +11,15 @@ $ td wf secrets --project cdp_segments --set td.apikey
 ```
 
 ### Prepare database and table
-You need to have following database and table to which data are imported. 
+You need to have following database and table to which data are imported.
 ```
 $ td db:create example_db
 $ td table:create master_segment_lists segment_lists
 ```
 
 ### TD endpoint
-You need to modify td_endpoint / cdp_endpoint setting in dig file for your TD region accordingly. 
-See our [document](https://support.treasuredata.com/hc/en-us/articles/360001474288-Sites-and-Endpoints#Endpoints) for details.
+You need to modify td_endpoint / cdp_endpoint setting in dig file for your TD region accordingly.
+See our [document](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1085143/Sites+and+Endpoints#Endpoints) for details.
 ```
     td_endpoint: "https://api.treasuredata.co.jp/"
     cdp_endpoint: "https://api-cdp.treasuredata.co.jp/"

--- a/tool-box/s3_presigned/s3.dig
+++ b/tool-box/s3_presigned/s3.dig
@@ -16,7 +16,7 @@ _export:
     image: "digdag/digdag-python:3.7"
   _env:
     # For secrets documentation,
-    # See https://support.treasuredata.com/hc/en-us/articles/360001266788-Workflows-Secrets-Management
+    # See https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
     S3_ACCESS_KEY_ID: ${secret:s3.access_key_id}
     S3_SECRET_ACCESS_KEY: ${secret:s3.secret_access_key}
 

--- a/tool-box/table-creates-and-drops-log/README.md
+++ b/tool-box/table-creates-and-drops-log/README.md
@@ -7,7 +7,7 @@ This workflow uses three inputs to determine anomalies within an account's audit
 These anomalous actions will be recorded in a new table to empower users to investigate the create and delete actions.
 Currently this workflow only works within a single account. If you own multiple accounts please either set up this
 workflow for each account you want monitored or work with your Treasure Data team to discuss the possibility of expanding
-this workflow's scope. 
+this workflow's scope.
 
 A unique list of tables that are impacted by anomalous changes will also be created which will reslut in fewer items than
 the create/delete action log. This view may have significantly fewer records and a better starting point for investigation.
@@ -30,14 +30,14 @@ filter out any regularly scheduled deletes/creates. Work with your team to under
 creates/deletes per table_name would be within your anomaly_range_days timeframe. Remember that you can always change
 this later on if you find you are capturing regularly scheduled actions.
 
-You will also be able to specify a mailing_list of emails to recieve anomaly notifications, exclude_databases and 
+You will also be able to specify a mailing_list of emails to recieve anomaly notifications, exclude_databases and
 exclude_tables lists of databases and/or tables you would like excluded from the analysis.
 
 ### Using Google Sheets
 
 By using Google Sheets with this workflow you will be able to instantly dig into analysis of anomalous creates/deletes
 within a spreadsheet rather needing to export or query this data in an additional workflow. If you do not wish to use
-this option please make sure to place a '#' before each line in the workflow related to Google Sheets. This includes 
+this option please make sure to place a '#' before each line in the workflow related to Google Sheets. This includes
 variables: 'google_sheet_id' and 'google_sheet_connection_name' as well as the step '+create_google_sheet_of_anomalous_jobs'.
 
 
@@ -47,27 +47,27 @@ variables: 'google_sheet_id' and 'google_sheet_connection_name' as well as the s
     * Copy and paste the anomalous_table_creates_and_deletes_log.dig into the workflow.
 2. Specify the options available:
     * **database:** Set the name of an existing database where you would like your log files to be maintained. If there is not
-already a database you would like to use, please [create one](https://support.treasuredata.com/hc/en-us/articles/360001266348-Database-and-Table-Management) 
+already a database you would like to use, please [create one](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083644/Database+and+Table+Management)
 and enter the name here.
     * **lookback_range_days:** Should be an intiger representing a number of days, see Overview for more details.
     * **anomaly_range_days:** Should be an intiger representing a number of days, see Overview for more details.
     * **anomaly_threashold:** Should be an intiger representing a number of days, see Overview for more details.
     * **google_sheet_id:** Create a blank Google Sheet shared to the appropriate audience to store the log of anomalous create/
-delete actions. There is an 
+delete actions. There is an
 [ID in the URL](https://developers.google.com/sheets/api/guides/concepts)
 , copy that ID and paste it into the google_sheet_id: in the workflow. If you do not want to use Google Sheets just enter
 '#' in front of this variable and in all lines within the '+create_google_sheet_of_anomalous_jobs' step of the workflow.
-    * **google_sheet_connection_name:** Enter the name of your 
-[Google Sheets connection](https://support.treasuredata.com/hc/en-us/articles/360009671913-Google-Sheets-Export)
+    * **google_sheet_connection_name:** Enter the name of your
+[Google Sheets connection](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081625/Google+Sheets+Export+Integration)
 within your Treasure Data account.
     * **mailing_list:** Enter all emails you would like to recieve notifications of anomalous actions seperated by commas.
     * **exclude_databases:** If you do not wish to exclude databases please enter: []. Otherwise use regex to identify the
     list the databases you would like to exclude, each on a new line preceeded by a '-'.
     * **exclude_tables:** If you do not wish to exclude tables please enter: []. Otherwise use regex to identify the
-    list the tables you would like to exclude, each on a new line preceeded by a '-'. Please consider the full 
+    list the tables you would like to exclude, each on a new line preceeded by a '-'. Please consider the full
     database_name.table_name of tables in this section.
 3. If you are opting out of using Google Sheets for an output, please make sure to place a '#' before each line in the
-workflow related to Google Sheets. This includes variables: 'google_sheet_id' and 'google_sheet_connection_name' as well as 
+workflow related to Google Sheets. This includes variables: 'google_sheet_id' and 'google_sheet_connection_name' as well as
 the step '+create_google_sheet_of_anomalous_jobs'.
 4. You are now ready to run the workflow and ensure setup is correct.
 5. Schedule the workflow to ensure you stay up to date with new creates/deletes accross your account.


### PR DESCRIPTION
We changed our documentation from `support.treasuredata.com` to `tddocs.atlassian.net`. So I revised the old URLs.