### PR TITLE
specify tag_fields as string

### DIFF
--- a/integration-box/yahoo-dmp/README.md
+++ b/integration-box/yahoo-dmp/README.md
@@ -58,15 +58,15 @@ information are provided by TreasureData support team.
     For Direct Targeting
     ```
       tag_fields:
-          p: ******
-          lid: ******
+          p: "******"
+          lid: "******"
     ```
 
     CustomSegment Targeting
     ```
       tag_fields          :
-        _a: ******
-        _d: ******
+        _a: "******"
+        _d: "******"
         vars:
           type  : 1
           price : 2

--- a/integration-box/yahoo-dmp/README.md
+++ b/integration-box/yahoo-dmp/README.md
@@ -71,7 +71,7 @@ information are provided by TreasureData support team.
           type  : 1
           price : 2
     ```
-    `_a` is a clientId for Yahoo! DMP, `_b` is a DatasourceNo for Yahoo! DMP. Both values are provided by Yahoo. (Please contact Yahoo representative)
+    `_a` is a clientId for Yahoo! DMP, `_b` is a DatasourceNo for Yahoo! DMP. Both values are provided by Yahoo (Please contact Yahoo representative). Both _a and _b values are required to be enclosed by quotation because those values could be like 0001 which are expected as string.
     As for `vars` value, you have to set combinations of a column name and column number.
     Assuming that your sql result is following, you should set type: 1 and price: 2.
     ```

--- a/integration-box/yahoo-dmp/yahoodmp_integration.dig
+++ b/integration-box/yahoo-dmp/yahoodmp_integration.dig
@@ -14,8 +14,8 @@ _export:
   uid_key             : ******
   brand_guid          : ******
   tag_fields          :
-      p: ******
-      lid: ******
+      p: "******"
+      lid: "******"
   _env:
     x_api_key: ${secret:x_api_key}
 

--- a/integration-box/yahoo-dmp/yahoodmp_integration.dig
+++ b/integration-box/yahoo-dmp/yahoodmp_integration.dig
@@ -1,6 +1,6 @@
 _export:
   td:
-    database: ******
+    database: sync_user_db
 
 +get_presigned_url:
   docker:


### PR DESCRIPTION
Some Yahoo! DMP parameters could have number parameter as string like `0005`. In order to handle it as string explicitly, need to enclose with quotation.