### PR TITLE
remove a unnecessary command and fix gcs.yml style

### DIFF
--- a/td_load/gcs/README.md
+++ b/td_load/gcs/README.md
@@ -4,21 +4,12 @@ This example workflow ingests data in daily basis, using [Treasure Data's Data C
 
 The workflow also uses [Secrets](https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line) feature, so that you don't have to include your database credentials to your workflow files.
 
-# Prerequisites (v0.9.21 or earlier)
-
-NOTE: Latest version fixes this issue.
-
-In order to register your GCP's json_key in Secrets, please convert "\n" to "\\n" in your json file.
-
-    # Convert json_key for Secrets
-    $ awk '{gsub("\\\\n","\\\\n"); print $0;}' credential.json > converted.json
-
 # How to Run for Local Mode
 
 First, please set database credentials by `td wf secrets` command.
 
     # Set Secrets for local
-    $ td wf secrets --local td_load_example --set gcp.json_key=@converted.json
+    $ td wf secrets --local td_load_example --set gcp.json_key=@credentails.json
 
 Now you can reference these credentials by `${secret:}` syntax within yml file for `td_load` operator.
 
@@ -38,7 +29,7 @@ First, please upload the workflow.
 Next, please set database credentials by `td wf secrets` command.
 
     # Set Secrets for Server
-    $ td wf secrets --project td_load_gcs --set gcp.json_key=@converted.json
+    $ td wf secrets --project td_load_gcs --set gcp.json_key=@credentails.json
 
 Now you can reference these credentials by `${secret:}` syntax within yml file for `td_load` operator.
 

--- a/td_load/gcs/config/gcs.yml
+++ b/td_load/gcs/config/gcs.yml
@@ -1,17 +1,16 @@
 in:
   type: gcs
   auth_method: json_key
-  json_keyfile:
-    content: "${secret:gcp.json_key}"
+  json_keyfile: { content: "${secret:gcp.json_key}" }
   bucket: "${gcs.bucket}"
   path_prefix: "/filename_${session_date}.csv"
   decoders:
-    - {type: gzip}
+    - { type: gzip }
   parser:
     charset: UTF-8
     newline: CRLF
     type: csv
-    delimiter: ','
+    delimiter: ","
     quote: '"'
     escape: '"'
     trim_if_not_quoted: false
@@ -19,13 +18,13 @@ in:
     allow_extra_columns: false
     allow_optional_columns: false
     columns:
-    - {name: user, type: string}
-    - {name: host, type: string}
-    - {name: path, type: string}
-    - {name: referer, type: string}
-    - {name: code, type: long}
-    - {name: agent, type: string}
-    - {name: size, type: long}
-    - {name: method, type: string}
-    - {name: time, type: long}
+      - { name: user, type: string }
+      - { name: host, type: string }
+      - { name: path, type: string }
+      - { name: referer, type: string }
+      - { name: code, type: long }
+      - { name: agent, type: string }
+      - { name: size, type: long }
+      - { name: method, type: string }
+      - { name: time, type: long }
 out: {}


### PR DESCRIPTION
## The purpose

I intend that users who refer to gcs.yml sample would not convert their json_key files and use as it is through this pull request.

## What I did
I removed the below unnecessary command from README.md as this operation is not required at the current version.

```
# Convert json_key for Secrets
$ awk '{gsub("\\\\n","\\\\n"); print $0;}' credential.json > converted.json
```