### PR TITLE
Replace obsolete support links with new tddocs links

### DIFF
--- a/integration-box/s3/README.md
+++ b/integration-box/s3/README.md
@@ -4,7 +4,7 @@ This is a simple example integration to upload/download a data from Python Custo
 
 Ensure to create S3 bucket your own, and your S3 bucket has appropriate policy to upload/download from Python Custom Scripting. See also https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html
 
-To set credentials securely, we recommend to use secrets for Treasure Workflow. See also https://support.treasuredata.com/hc/en-us/articles/360001266788-Workflows-Secrets-Management
+To set credentials securely, we recommend to use secrets for Treasure Workflow. See also https://tddocs.atlassian.net/wiki/spaces/PD/pages/1085133/About+Workflow+Secret+Management
 
 ## Prerequisites
 

--- a/integration-box/yahoo-dmp/README.md
+++ b/integration-box/yahoo-dmp/README.md
@@ -7,7 +7,7 @@ There are 2 ways to create targeting campaign on Yahoo! Display Network.
 - Require to have accounts for TreasureData, Yahoo Display Network, Yahoo! DMP
 - Require to have clientId(referred to `_a`), DatasourceNo(referred to `_b`) provided by Yahoo!
 - Require to have vendor_guid, entity_id, uid_key, and x-api-key provided by TreasureData support team.
-- Set up Treasure Data Toolbelt: Command-line Interface (https://support.treasuredata.com/hc/en-us/articles/360000720048-Treasure-Data-Toolbelt-Command-line-Interface) 
+- Set up Treasure Data Toolbelt: Command-line Interface (https://tddocs.atlassian.net/wiki/spaces/PD/pages/2065286/Using+TD+Toolbelt)
 
 # Installation (Setup)  
 Download this workflow. 

--- a/td/googleads_remarketing_lists/README.md
+++ b/td/googleads_remarketing_lists/README.md
@@ -1,10 +1,10 @@
 # Workflow: td example (Result Output to Google AdWords Remarketing Lists)
 
-This example workflow outputs data to a google adwords remarketing lists using [Writing Job Results into Google AdWords Remarketing Lists](https://support.treasuredata.com/hc/en-us/articles/360001666767-Writing-Job-Results-into-Google-AdWords-Remarketing-Lists) with [td](http://docs.digdag.io/operators/td.html) operator.
+This example workflow outputs data to a google adwords remarketing lists using [Writing Job Results into Google AdWords Remarketing Lists](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082644/Google+Ads+Remarketing+Lists+Export+Integration) with [td](http://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
-In order to register your credential in Treasure Data, please create connection by following the instructions on this page [Writing Job Results into Google Adwords Remarketing Lists]( https://support.treasuredata.com/hc/en-us/articles/360001666767-Writing-Job-Results-into-Google-AdWords-Remarketing-Lists) 
+In order to register your credential in Treasure Data, please create connection by following the instructions on this page [Writing Job Results into Google Adwords Remarketing Lists](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082644/Google+Ads+Remarketing+Lists+Export+Integration)
 
 The connection name is used in the dig file.
 
@@ -51,8 +51,8 @@ Available parameters for `result_settings` are here.
 - maximum_retry_interval_millis : Max retry wait in milliseconds. (int, optional, default: 300000)
 
 
-For more details, please see [Treasure Data documentation (GUI)](https://support.treasuredata.com/hc/en-us/articles/360001262227-Treasure-Workflow-Quick-Start-Tutorial-for-the-GUI)
-or [Treasure Data documentation(CLI)](https://support.treasuredata.com/hc/en-us/articles/360001262207-Treasure-Workflow-Quick-Start-Tutorial-for-the-CLI)
+For more details, please see [Treasure workflow documentation (GUI)](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084846/Using+Workflow+from+TD+Console)
+or [Treasure workflow documentation (CLI)](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1672953/Using+TD+Workflow+from+the+Command+Line)
 
 # Next Step
 If you have any questions, please contact support@treasuredata.com.


### PR DESCRIPTION
Fixed the broken support links and replaced them with new tddocs link in few different places.

After applying these changes, running `grep -inHR '//support' .` under `treasure-boxes` shows no other outdated support page links.