### PR TITLE
Update Treasure Data document URL

### DIFF
--- a/analytics-box/fuzzy-matching/README.md
+++ b/analytics-box/fuzzy-matching/README.md
@@ -6,7 +6,7 @@ This project provides the workflows necessary to use Fuzzy Matching algorithms l
 ## Getting Started
 
 1. Download this folder locally.
-2. Use [TD Toolbelt](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083651/Treasure+Workflow+Quick+Start+using+TD+Toolbelt+in+a+CLI) to upload this folder as a Treasure Workflow project into your Treasure data account
+2. Use [TD Toolbelt](https://docs.treasuredata.com/display/public/PD/Treasure+Workflow+Quick+Start+using+TD+Toolbelt+in+a+CLI) to upload this folder as a Treasure Workflow project into your Treasure data account
 3. Provide the database name ,table name(ex. user_master with first and last name information) and column name with information of first and last name in the demo_fuzzy.dig file as variables
 4. Run the demo_fuzzy.dig file
 

--- a/data-box/customer-profile-enrichment/README.md
+++ b/data-box/customer-profile-enrichment/README.md
@@ -12,7 +12,7 @@ This project provides the workflows necessary to enrich customer profiles with s
 ----
 ## Implementation
 1. Download this folder locally
-2. Use [TD Toolbelt](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083651/Treasure+Workflow+Quick+Start+using+TD+Toolbelt+in+a+CLI) to upload this folder as a Treasure Workflow project in your Treasure Data account
+2. Use [TD Toolbelt](https://docs.treasuredata.com/display/public/PD/Treasure+Workflow+Quick+Start+using+TD+Toolbelt+in+a+CLI) to upload this folder as a Treasure Workflow project in your Treasure Data account
 3. Define the variables listed below to specify what data to process in order to enrich the necessary customer profiles
 
 ----

--- a/data-box/email-validation/README.md
+++ b/data-box/email-validation/README.md
@@ -8,7 +8,7 @@ This box provides a sample SQL query that can be used to assess whether or not a
 ----
 ## Implementation
 1. Download this folder locally
-2. Use [TD Toolbelt](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083651/Treasure+Workflow+Quick+Start+using+TD+Toolbelt+in+a+CLI) to upload this folder as a Treasure Workflow project in your Treasure Data account
+2. Use [TD Toolbelt](https://docs.treasuredata.com/display/public/PD/Treasure+Workflow+Quick+Start+using+TD+Toolbelt+in+a+CLI) to upload this folder as a Treasure Workflow project in your Treasure Data account
 3. Define the variables listed below to specify what data to process in order to enrich the necessary customer profiles
 
 ----

--- a/integration-box/auth0-callback/Hooks/sample_hooks_post-user-registration.js
+++ b/integration-box/auth0-callback/Hooks/sample_hooks_post-user-registration.js
@@ -18,7 +18,7 @@ module.exports = function (user, context, cb) {
     // Set your TD's environment info
     let options = {
         // Set the destination Endpoint, DB name and, Table name
-        // Endpoint: https://tddocs.atlassian.net/wiki/spaces/PD/pages/1085143/Sites+and+Endpoints (JS/Mobile SDK/Postback part)
+        // Endpoint: https://docs.treasuredata.com/display/public/PD/Sites+and+Endpoints (JS/Mobile SDK/Postback part)
         url: 'https://{ENDPOINT}/postback/v3/event/{YOUR_DB}/{YOUR_TABLE}',
         method: 'POST',
         headers: {

--- a/integration-box/auth0-callback/README.md
+++ b/integration-box/auth0-callback/README.md
@@ -28,7 +28,7 @@ https://auth0.com/docs/hooks
 Treasure Data users can ingest data through the public REST API. You can use Treasure Data to create custom webhooks into your data.
 
 Please see:
-https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083818/Postback+API
+https://docs.treasuredata.com/display/public/PD/Postback+API
 
 
 # Sample

--- a/integration-box/auth0-callback/Rules/sample_rules_post-user-registration.js
+++ b/integration-box/auth0-callback/Rules/sample_rules_post-user-registration.js
@@ -15,7 +15,7 @@ function (user, context, callback) {
     // Set your TD's environment info
     let option = {
         // Set the destination Endpoint, DB name and, Table name
-        // Endpoint: https://tddocs.atlassian.net/wiki/spaces/PD/pages/1085143/Sites+and+Endpoints (JS/Mobile SDK/Postback part)
+        // Endpoint: https://docs.treasuredata.com/display/public/PD/Sites+and+Endpoints (JS/Mobile SDK/Postback part)
         url: 'https://{ENDPOINT}/postback/v3/event/{YOUR_DB}/{YOUR_TABLE}',
         method: 'POST',
         headers: {

--- a/integration-box/brightcove/readme.md
+++ b/integration-box/brightcove/readme.md
@@ -21,7 +21,7 @@ As of 2019-7-2, we supported for Grid and Carousel type of creative.
 
 ## Log detail
 
-In Addition to [default params of TreasureData Javascript SDK](https://docs.treasuredata.com/articles/javascript-sdk#step-2-initialize-amp-send-events-to-the-cloud), Each event logs as follows parameters.
+In Addition to [default params of TreasureData Javascript SDK](https://docs.treasuredata.com/display/public/INT/Brightcove+Player+Import+Integration#BrightcovePlayerImportIntegration-Parameters), Each event logs as follows parameters.
 
 |`bc_event` column|additional column|example|
 |:---:|:---:|:---:|

--- a/integration-box/csv_import_via_http/README.md
+++ b/integration-box/csv_import_via_http/README.md
@@ -9,7 +9,7 @@ This workflow project including CustomScript (Python) enables you to import csv 
 - column_setting_file: set CSV setting file name.
 
 ## Set apikey as secret ()
-https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
+https://docs.treasuredata.com/display/public/PD/Setting+Workflow+Secrets+from+the+Command+Line
 
 ## Edit csv_setting.json
 You can change behavior followings.
@@ -18,7 +18,7 @@ You can change behavior followings.
 
 ## update workflow project to TreasureData
 Submit workflow to TreasureData.
-https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083651/Treasure+Workflow+Quick+Start+using+TD+Toolbelt+in+a+CLI
+https://docs.treasuredata.com/display/public/PD/Treasure+Workflow+Quick+Start+using+TD+Toolbelt+in+a+CLI
 
 ## Appendix
 You can specify http settings in detail depend on pandas.read_csv function (encoding, compression, and so on).

--- a/integration-box/cuenote-import/README.md
+++ b/integration-box/cuenote-import/README.md
@@ -36,7 +36,7 @@ td wf secrets --project cuenote_import --set td.apikey td.apiserver td.database
 |variable|sample|description|
 |:----|:----|:----|
 |`td.apikey`|`000/1234567890abcde`|Treasure Data's API key with Master-Key permission|
-|`td.apiserver`|`https://api.treasuredata.com`|An endpoint of Treasure Data API. Use your [regional endpoint](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1085143/Sites+and+Endpoints).|
+|`td.apiserver`|`https://api.treasuredata.com`|An endpoint of Treasure Data API. Use your [regional endpoint](https://docs.treasuredata.com/display/public/PD/Sites+and+Endpoints).|
 |`td.database`|`cuenote`|A name of database dedicated for Cuenote integration.|
 
 ### 3. Set variables for Cuenote API

--- a/integration-box/datarobot/README.md
+++ b/integration-box/datarobot/README.md
@@ -10,7 +10,7 @@ Second, `pytd` creates a table on Treasure Data with the dataframe.
 
 | Variable | Description | Example |
 | -------- | ----------- | --------|
-| td.apikey | Master API Key for Treasure Data. [link](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081428/Getting+Your+API+Keys) | `1234/abcdefghijklmnopqrstuvwxyz1234567890`|
+| td.apikey | Master API Key for Treasure Data. [link](https://docs.treasuredata.com/display/public/PD/Getting+Your+API+Keys) | `1234/abcdefghijklmnopqrstuvwxyz1234567890`|
 | td.database | Treasure Data's database name to export data. | `example_db` |
 | td.table | Treasure Data's table name to export data. | `example_table` |
 | td.sql | SQL to pass to Treasure Data's to retrieve a prediction data. | `select * from pred_data` |

--- a/integration-box/elastic-map-reduce/README.md
+++ b/integration-box/elastic-map-reduce/README.md
@@ -4,7 +4,7 @@ This example workflow allows the user to run a simple python script using Treasu
 
 # Preparation
 
-This example workflow uses [TD-Pandas](https://docs.treasuredata.com/articles/jupyter-pandas) for creating a pandas dataframe from a td-query, and pushing a dataframe back to Treasure Data as a new table.
+This example workflow uses [TD-Pandas](https://docs.treasuredata.com/display/public/PD/Pandas+and+Jupyter+Configuration+for+Treasure+Data) for creating a pandas dataframe from a td-query, and pushing a dataframe back to Treasure Data as a new table.
 
 This example workflow also uses the [EMR-operator](https://docs.digdag.io/operators/emr.html), that creates a new minimal ephemeral cluster with just one node.
 

--- a/integration-box/mbed-os/README.md
+++ b/integration-box/mbed-os/README.md
@@ -64,7 +64,7 @@ Compile the Box code, and enter to a serial terminal:
 mbed compile --target auto --toolchain GCC_ARM --flash --sterm
 ```
 
-The terminal tells you that device heap information is being collected and sent to [Treasure Data Postback API](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083818/Postback+API):
+The terminal tells you that device heap information is being collected and sent to [Treasure Data Postback API](https://docs.treasuredata.com/display/public/PD/Postback+API):
 
 ```
 Treasure Boxes (Integration): Mbed OS + Treasure Data
@@ -94,10 +94,10 @@ This Box is a modified version of the following repository:
 
 Official documentation using Mbed Online Compiler is available at:
 
-- [Data Ingestion from Mbed OS (HTTP over Wi-Fi)](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081510/Mbed+OS+for+Device+Tracking)
+- [Data Ingestion from Mbed OS (HTTP over Wi-Fi)](https://docs.treasuredata.com/display/public/INT/Mbed+OS+for+Device+Tracking)
 
 Besides Postback API, there are alternative ways to ingest data from Mbed OS to Treasure Data; for example:
 
 - [Fluentd](https://github.com/BlackstoneEngineering/mbed-os-example-fluentlogger)
-- [Fluent Bit](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082746/Embedded+Apps+C+and+C+Import+Integration)
+- [Fluent Bit](https://docs.treasuredata.com/pages/releaseview.action?pageId=329063)
 - [MQTT Broker](../mqtt)

--- a/integration-box/mqtt/README.md
+++ b/integration-box/mqtt/README.md
@@ -1,6 +1,6 @@
 # Treasure Data MQTT Broker
 
-[Treasure Data MQTT broker](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084422/MQTT+Broker+with+Treasure+Data) allows you to ingest data through the [MQTT protocol](http://mqtt.org/).
+[Treasure Data MQTT broker](https://docs.treasuredata.com/display/public/INT/MQTT+Broker+with+Treasure+Data) allows you to ingest data through the [MQTT protocol](http://mqtt.org/).
 
 Notice that our broker only accepts `publish` operation against a topic `mqtt-ingest`, and you cannot subscribe the topic. Plus, the MQTT broker currently requires client to be connected over SSL with a pair of given client certificate and RSA private key.
 

--- a/integration-box/pelion-device-management/README.md
+++ b/integration-box/pelion-device-management/README.md
@@ -6,7 +6,7 @@ PDM itself, however, does not store device data (i.e., resource values of your d
 
 ## Overview
 
-This Box demonstrates a simple way of pulling resource values from PDM to TD via [`ConnectAPI`](https://www.pelion.com/docs/device-management/current/service-api-references/device-management-connect.html) called by [PDM Python Client](https://github.com/ARMmbed/mbed-cloud-sdk-python) running on the [Treasure Workflow Custom Scripting](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084247/Introduction+to+Custom+Scripts) capability.
+This Box demonstrates a simple way of pulling resource values from PDM to TD via [`ConnectAPI`](https://www.pelion.com/docs/device-management/current/service-api-references/device-management-connect.html) called by [PDM Python Client](https://github.com/ARMmbed/mbed-cloud-sdk-python) running on the [Treasure Workflow Custom Scripting](https://docs.treasuredata.com/display/public/PD/Introduction+to+Custom+Scripts) capability.
 
 We assume your device has already been registered to PDM. For instance, if you are right after finishing [PDM IoT Connection Tutorial](https://os.mbed.com/guides/connect-device-to-pelion/), device and resource information can be listed as follows:
 
@@ -28,7 +28,7 @@ Next, push the workflow to TD:
 td wf push pelion_device
 ```
 
-Here, get your API key and endpoint from [PDM](https://preview.pelion.com/docs/device-management/current/integrate-web-app/api-keys.html) and [TD](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081428/Getting+Your+API+Keys), and set them to the workflow secrets:
+Here, get your API key and endpoint from [PDM](https://preview.pelion.com/docs/device-management/current/integrate-web-app/api-keys.html) and [TD](https://docs.treasuredata.com/display/public/PD/Getting+Your+API+Keys), and set them to the workflow secrets:
 
 ```sh
 td wf secrets \

--- a/integration-box/pelion-device-management/pelion_device.dig
+++ b/integration-box/pelion-device-management/pelion_device.dig
@@ -1,7 +1,7 @@
 timezone: UTC
 
 # See
-# https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081710/Scheduling+Workflows+from+the+Command+Line
+# https://docs.treasuredata.com/display/public/PD/Scheduling+Workflows+from+the+Command+Line
 # for scheduling workflow
 schedule:
   hourly>: 00:00

--- a/integration-box/python/simple.dig
+++ b/integration-box/python/simple.dig
@@ -9,7 +9,7 @@
     _env:
         MY_ENV_VAR: "hello"
         # One can use secrets as well.
-        # See https://tddocs.atlassian.net/wiki/spaces/PD/pages/1085133/About+Workflow+Secret+Management
+        # See https://docs.treasuredata.com/display/public/PD/About+Workflow+Secret+Management
     docker:
         image: "digdag/digdag-python:3.7"
 

--- a/integration-box/rss/README.md
+++ b/integration-box/rss/README.md
@@ -14,7 +14,7 @@ $ td wf secrets --project rss_import --set td.apikey --set td.apiserver
 |Variable|Description|Example|
 |:---|:---|:---|
 |`td.apikey`|An API key to be used in the script. Access Type must be `Master Key`.|`1234/abcdefghijklmnopqrstuvwxyz1234567890`|
-|`td.apiserver`|TD's API endpoint starting with `https://`. See our [document](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1085143/Sites+and+Endpoints#Endpoints) for details.|`https://api.treasuredata.com`|
+|`td.apiserver`|TD's API endpoint starting with `https://`. See our [document](https://docs.treasuredata.com/display/public/PD/Sites+and+Endpoints#Endpoints) for details.|`https://api.treasuredata.com`|
 
 ### Set RSS url list
 Set rss_url_list you want to get imported in [rss_import.dig](rss_import.dig) file.

--- a/integration-box/s3/README.md
+++ b/integration-box/s3/README.md
@@ -4,7 +4,7 @@ This is a simple example integration to upload/download a data from Python Custo
 
 Ensure to create S3 bucket your own, and your S3 bucket has appropriate policy to upload/download from Python Custom Scripting. See also https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html
 
-To set credentials securely, we recommend to use secrets for Treasure Workflow. See also https://tddocs.atlassian.net/wiki/spaces/PD/pages/1085133/About+Workflow+Secret+Management
+To set credentials securely, we recommend to use secrets for Treasure Workflow. See also https://docs.treasuredata.com/display/public/PD/About+Workflow+Secret+Management
 
 ## Prerequisites
 

--- a/integration-box/s3/s3.dig
+++ b/integration-box/s3/s3.dig
@@ -10,7 +10,7 @@ _export:
     image: "digdag/digdag-python:3.7"
   _env:
     # For secrets documentation,
-    # See https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
+    # See https://docs.treasuredata.com/display/public/PD/Setting+Workflow+Secrets+from+the+Command+Line
     S3_ACCESS_KEY_ID: ${secret:s3.access_key_id}
     S3_SECRET_ACCESS_KEY: ${secret:s3.secret_access_key}
 

--- a/integration-box/scorer-cloud/README.md
+++ b/integration-box/scorer-cloud/README.md
@@ -112,7 +112,7 @@ group by
   1, 2
 ```
 
-See [documentation](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083429/Supported+Presto+and+TD+Functions#TD_INTERVAL) to learn more about `TD_INTERVAL`.
+See [documentation](https://docs.treasuredata.com/display/public/PD/Supported+Presto+and+TD+Functions) to learn more about `TD_INTERVAL`.
 
 Output can be:
 

--- a/integration-box/swimos/README.md
+++ b/integration-box/swimos/README.md
@@ -20,7 +20,7 @@ git apply ../../patch-tutorial.diff
 # set values to TD_WRITE_KEY, TD_DATABASE, TD_TABLE variables
 ```
 
-By running the Swim application, a mock data source publishes random records (e.g., `{'foo': 62, 'bar': 126, 'baz': 174}`) to a Web Agent, and the agent passes the records to [Treasure Data Postback API](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083818/Postback+API) along with setting value to the other [Lanes](https://developer.swim.ai/concepts/lanes/):
+By running the Swim application, a mock data source publishes random records (e.g., `{'foo': 62, 'bar': 126, 'baz': 174}`) to a Web Agent, and the agent passes the records to [Treasure Data Postback API](https://docs.treasuredata.com/display/public/PD/Postback+API) along with setting value to the other [Lanes](https://developer.swim.ai/concepts/lanes/):
 
 ```sh
 ./gradlew run

--- a/integration-box/yahoo-dmp/README.md
+++ b/integration-box/yahoo-dmp/README.md
@@ -7,7 +7,7 @@ There are 2 ways to create targeting campaign on Yahoo! Display Network.
 - Require to have accounts for TreasureData, Yahoo Display Network, Yahoo! DMP
 - Require to have clientId(referred to `_a`), DatasourceNo(referred to `_b`) provided by Yahoo!
 - Require to have vendor_guid, entity_id, uid_key, and x-api-key provided by TreasureData support team.
-- Set up Treasure Data Toolbelt: Command-line Interface (https://tddocs.atlassian.net/wiki/spaces/PD/pages/2065286/Using+TD+Toolbelt)
+- Set up Treasure Data Toolbelt: Command-line Interface (https://docs.treasuredata.com/display/public/PD/TD+Toolbelt)
 
 # Installation (Setup)  
 Download this workflow. 
@@ -94,7 +94,7 @@ $ td wf push yahoodmp_integration
 
 FYI
 Setting Workflow Secrets from TD Console
-https://tddocs.atlassian.net/wiki/spaces/PD/pages/219185771/Setting+Workflow+Secrets+from+TD+Console
+https://docs.treasuredata.com/display/public/PD/Setting+Workflow+Secrets+from+TD+Console
 
 # Mechanism 
 <img width="2999" alt="yahoodmp_integration" src="https://user-images.githubusercontent.com/248312/82309034-8d065700-99fd-11ea-8066-96923cf397b5.png">

--- a/machine-learning-box/ctr-prediction/README.md
+++ b/machine-learning-box/ctr-prediction/README.md
@@ -164,4 +164,4 @@ For further reading for algorithm and/or workflow details, please refer [this pa
 
 Treasure Workflow provides an easy way to predict not only CTR but also Conversion Rate (CVR). What you need to prepare is just a training table.
 
-[Contact us](https://www.treasuredata.com/contact_us) if you interested in [our paid consulting service](https://docs.treasuredata.com/articles/data-science-consultation).
+[Contact us](https://www.treasuredata.com/contact_us) if you interested in [our paid consulting service](https://docs.treasuredata.com/display/public/PD/Consultation).

--- a/machine-learning-box/house-price-prediction/README.md
+++ b/machine-learning-box/house-price-prediction/README.md
@@ -58,4 +58,4 @@ This workflow outputs predicted price of houses in `predictions` table as follow
 
 Treasure Workflow provides an easy way to predict continuous values, like a price or energy consumption, using Linear Regression predictor.
 
-[Contact us](https://www.treasuredata.com/contact_us) if you interested in [our paid consulting service](https://docs.treasuredata.com/articles/data-science-consultation).
+[Contact us](https://www.treasuredata.com/contact_us) if you interested in [our paid consulting service](https://docs.treasuredata.com/display/public/PD/Consultation).

--- a/machine-learning-box/ml_tips/README.md
+++ b/machine-learning-box/ml_tips/README.md
@@ -77,4 +77,4 @@ echo>: auc: 0.8044451551007356    logloss: 0.5337748192743182
 
 Treasure Workflow and Hivemall provide an easy way for feature engineerings such as feature scaling and missing value imputation.
 
-[Contact us](https://www.treasuredata.com/contact_us) if you interested in [our paid consulting service](https://docs.treasuredata.com/articles/data-science-consultation).
+[Contact us](https://www.treasuredata.com/contact_us) if you interested in [our paid consulting service](https://docs.treasuredata.com/display/public/PD/Consultation).

--- a/machine-learning-box/predictive-lead-scoring/README.md
+++ b/machine-learning-box/predictive-lead-scoring/README.md
@@ -17,7 +17,7 @@ Here is an overview of what we try to tackle:
 4. Integrate transformed job titles with other attributes
 5. Launch predictive analytics, and find out our potential customers for sales team
 
-In this page, we mainly focus on **step 2** to **5**. In order to transfer your SFDC data to Treasure Data as **step 1**, you first need to refer to the following article: **[How to integrate Salesforce data with Treasure Data](https://docs.treasuredata.com/articles/data-connector-salesforce)**.
+In this page, we mainly focus on **step 2** to **5**. In order to transfer your SFDC data to Treasure Data as **step 1**, you first need to refer to the following article: **[How to integrate Salesforce data with Treasure Data](https://docs.treasuredata.com/display/public/INT/Salesforce+Import+Integration)**.
 
 Note that you can skip **step 3** if you use [resources/title_mapping.csv](./resources/title_mapping.csv).
 
@@ -126,4 +126,4 @@ The following tables suggest probability which indicates how this qualified lead
 
 Treasure Machine Learning and Workflow make predictive analytics more handy. Once `prediction_qualified_lead` and/or `prediction_opportunity` table has been created, you can connect the result with the other tools such as SFDC itself and BI tools.
 
-[Contact us](https://www.treasuredata.com/contact_us) if you interested in [our paid consulting service](https://docs.treasuredata.com/articles/data-science-consultation).
+[Contact us](https://www.treasuredata.com/contact_us) if you interested in [our paid consulting service](https://docs.treasuredata.com/display/public/PD/Consultation).

--- a/machine-learning-box/recommendation/README.md
+++ b/machine-learning-box/recommendation/README.md
@@ -31,14 +31,14 @@ $ td wf push recommendation # push workflow to TD
 $ td wf start recommendation recommend --session now
 ```
 
-* [recommend.dig](recommend.dig) - TD workflow script for top-k item recommendation using [Matrix Factorization](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081696/MovieLens+20M+Rating+Prediction+by+Matrix+Factorization)
+* [recommend.dig](recommend.dig) - TD workflow script for top-k item recommendation using [Matrix Factorization](https://docs.treasuredata.com/display/public/PD/MovieLens+20M+Rating+Prediction+by+Matrix+Factorization)
 * [config/params.yml](config/params.yml) - defines configurable parameters for the recommendation workflow such as `k` of top-k. By the default, the workflow recommends top-10 items for each user.
 
 [<img src="docs/img/capture.png" alt="capture" max_height=300 />](http://showterm.io/31b8df49efcfbc2bfc5ef#fast)
 
 ### Workflow with PySpark
 
-You also can try [Spark.ml collaborative filtering](https://spark.apache.org/docs/2.4.0/ml-collaborative-filtering.html) recommendation for top-k item recommendation. Ensure both [Python Custom Scripting](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084247/Introduction+to+Custom+Scripts) and [td-spark](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082542/Using+Apache+Spark+Driver+TD-Spark+in+your+Spark+Environment) enabled.
+You also can try [Spark.ml collaborative filtering](https://spark.apache.org/docs/2.4.0/ml-collaborative-filtering.html) recommendation for top-k item recommendation. Ensure both [Python Custom Scripting](https://docs.treasuredata.com/display/public/PD/Introduction+to+Custom+Scripts) and [td-spark](https://docs.treasuredata.com/display/public/PD/Using+Apache+Spark+Driver+%28TD-Spark%29+in+your+Spark+Environment) enabled.
 
 ```sh
 $ ./data.sh
@@ -48,7 +48,7 @@ $ td wf secrets --project recommendation --set td.apikey --set td.apiserver
 $ td wf start recommendation recommend_spark --session now
 ```
 
-* [recommend_spark.dig](recommend_spark.dig) - TD workflow script for top-k item recommendation using [Matrix Factorization](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081696/MovieLens+20M+Rating+Prediction+by+Matrix+Factorization)
+* [recommend_spark.dig](recommend_spark.dig) - TD workflow script for top-k item recommendation using [Matrix Factorization](https://docs.treasuredata.com/display/public/PD/MovieLens+20M+Rating+Prediction+by+Matrix+Factorization)
 * [recommend.py](py_scripts/recommend.py) - Python script for PySpark ALS recommendation.
 * [config/params.yml](config/params.yml) - Configurable parameters for the recommendation workflow. This workflow uses `k` of top-k and `target` as database name. By the default, the workflow recommends top-10 items for each user.
 
@@ -72,4 +72,4 @@ For further reading for algorithm and/or workflow details, please refer [this pa
 
 Treasure Workflow provides an easy way to generate top-k recommendations. What you need to prepare is just a training table.
 
-[Contact us](https://www.treasuredata.com/contact_us) if you interested in [our paid consulting service](https://docs.treasuredata.com/articles/data-science-consultation).
+[Contact us](https://www.treasuredata.com/contact_us) if you interested in [our paid consulting service](https://docs.treasuredata.com/display/public/PD/Consultation).

--- a/machine-learning-box/recommendation/docs/more.md
+++ b/machine-learning-box/recommendation/docs/more.md
@@ -1,7 +1,7 @@
 After you read this page, you can:
 
 - get a basic understanding of a recommendation technique,
-- understand basic usage of [Treasure Workflow](https://docs.treasuredata.com/articles/workflows) for a recommendation purpose,
+- understand basic usage of [Treasure Workflow](https://docs.treasuredata.com/display/public/PD/Workflows+and+Machine+Learning) for a recommendation purpose,
 - try the template on publicly available data,
 - make recommendation on your own data stored in TD.
 

--- a/machine-learning-box/tf-idf/README.md
+++ b/machine-learning-box/tf-idf/README.md
@@ -63,4 +63,4 @@ For further reading for algorithm and/or workflow details, please refer [this pa
 
 Treasure Workflow and TF-IDF weighting technique enable you to analyze a collection of massive documents on cloud. Once you find TF-IDF scores and top-k words for each document, you can use the results in a wide variety of applications such as document clustering and recommendation.
 
-[Contact us](https://www.treasuredata.com/contact_us) if you interested in [our paid consulting service](https://docs.treasuredata.com/articles/data-science-consultation).
+[Contact us](https://www.treasuredata.com/contact_us) if you interested in [our paid consulting service](https://docs.treasuredata.com/display/public/PD/Consultation).

--- a/machine-learning-box/topic-modeling/README.md
+++ b/machine-learning-box/topic-modeling/README.md
@@ -84,4 +84,4 @@ What you need to prepare is just an input table.
 Note that you can find stopwords in various languages in [PostgreSQL repository](https://github.com/postgres/postgres/tree/master/src/backend/snowball/stopwords).
 Better to replace [stopwords.csv](.resources/stopwords.csv) for non-English texts.
 
-[Contact us](https://www.treasuredata.com/contact_us) if you interested in [our paid consulting service](https://docs.treasuredata.com/articles/data-science-consultation).
+[Contact us](https://www.treasuredata.com/contact_us) if you interested in [our paid consulting service](https://docs.treasuredata.com/display/public/PD/Consultation).

--- a/scenarios/compare_last_results/README.md
+++ b/scenarios/compare_last_results/README.md
@@ -13,7 +13,7 @@ The `store_last_results` can store the first 1 row of the query results to ${td.
 
 In this scenario, some workflow operators are used. Please refer to the documentation for each operator.
 
- - `td>: operator`: [td>: Running Treasure Data Query](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084693/Reference+for+Treasure+Data+Operators#td%3E:)
+ - `td>: operator`: [td>: Running Treasure Data Query](https://docs.treasuredata.com/display/public/PD/Reference+for+Treasure+Data+Operators#ReferenceforTreasureDataOperators-td%3E:)
  - `for_each>: operator`: [for_each>: Repeat tasks for values](https://docs.digdag.io/operators/for_each.html)
  - `if>: operator`: [if>: Conditional execution](https://docs.digdag.io/operators/if.html)
 

--- a/scenarios/expand_json_s3/README.md
+++ b/scenarios/expand_json_s3/README.md
@@ -2,7 +2,7 @@
 
 This example workflow ingests data from datasource with [JSON Lines](http://jsonlines.org/) format using [expand_json filter](https://github.com/civitaspo/embulk-filter-expand_json).
 
-The workflow also uses [Secrets](https://docs.treasuredata.com/articles/workflows-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
+The workflow also uses [Secrets](https://docs.treasuredata.com/display/public/PD/Workflows+and+Machine+Learning-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
 
 # File format
 

--- a/scenarios/expand_json_s3/config/load.yml
+++ b/scenarios/expand_json_s3/config/load.yml
@@ -1,6 +1,6 @@
 # For more advanced config options, please check these URLs.
-# @see https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082523/Amazon+S3+Import+Integration
-# @see https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083538/expand+json+Filter+Function
+# @see https://docs.treasuredata.com/display/public/INT/Amazon+S3+Import+Integration
+# @see https://docs.treasuredata.com/display/public/PD/Expanding+JSON+Filter
 # @see https://github.com/embulk/embulk-input-s3
 ---
 in:

--- a/scenarios/get_wf_runnning_status/README.MD
+++ b/scenarios/get_wf_runnning_status/README.MD
@@ -10,7 +10,7 @@ To get running status of another workflow
 You have to change it if your account's site is located in EU or Tokyo.
 
 Please refer to the doc for more details.
-https://tddocs.atlassian.net/wiki/spaces/PD/pages/1085143/Sites+and+Endpoints
+https://docs.treasuredata.com/display/public/PD/Sites+and+Endpoints
 
 # How to Run
 First, upload the project.

--- a/scenarios/intermediate_table/README.md
+++ b/scenarios/intermediate_table/README.md
@@ -12,7 +12,7 @@ Steps 2 and 3 can be made into a Treasure Workflow which enables you to define r
 
 You can read additional information:
 1. [Efficiently Analyze Infinitely Growing Data with Incremental Queries](https://blog.treasuredata.com/blog/2017/07/25/analyze-infinitely-growing-data-incremental-queries/)
-2. [Treasure Workflow Docs](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081518/Workflow+Reference)
+2. [Treasure Workflow Docs](https://docs.treasuredata.com/display/public/PD/Workflow+Reference)
 
 ## Scenario
 

--- a/scenarios/kill_wf_attempt/README.md
+++ b/scenarios/kill_wf_attempt/README.md
@@ -13,7 +13,7 @@ To kill the attempt automatically if the attempt violates sla.
 You have to change baseurl if your account's site is EU, Tokyo.
 
 Please refer to the doc for more details.
-https://tddocs.atlassian.net/wiki/spaces/PD/pages/1085143/Sites+and+Endpoints
+https://docs.treasuredata.com/display/public/PD/Sites+and+Endpoints
 
 # How to Run
 First, upload the project.

--- a/scenarios/result_export/README.md
+++ b/scenarios/result_export/README.md
@@ -27,7 +27,7 @@ Note: http.authorization is used as header in your API request.
 You must http.authorization like this : ```TD1 <Your APIKey>```
 
 For detail, please refer to the below page.
-https://tddocs.atlassian.net/wiki/spaces/PD/overview
+https://docs.treasuredata.com/display/public/PD/Product+Documentation+Home
 
 
 Third, please set your other services' credentials by ```td wf secrets``` command.
@@ -42,7 +42,7 @@ $ td wf secret --project export_result_parallel --set @credential.yml
 ```
 
 For detail, please refer to below page.
-https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
+https://docs.treasuredata.com/display/public/PD/Setting+Workflow+Secrets+from+the+Command+Line
 
 Finally, you can trigger the session manually.
 

--- a/scenarios/result_export/export_result_TD/README.md
+++ b/scenarios/result_export/export_result_TD/README.md
@@ -4,8 +4,8 @@ You can export result to Another Treasure Data Account without running the same 
 
 ## Note
 
-Using `td_result_export` operator is much easier and simpler for calling API by yourself.  
-If you want to know how to use `td_result_export`, please check the [Doc](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084693/Reference+for+Treasure+Data+Operators#td_result_export%3E%3A)  
+Using `td_result_export` operator is much easier and simpler for calling API by yourself.
+If you want to know how to use `td_result_export`, please check the [Doc](https://docs.treasuredata.com/display/public/PD/Reference+for+Treasure+Data+Operators#ReferenceforTreasureDataOperators-td_result_export%3E:)
 
 The sample is [here](https://github.com/treasure-data/treasure-boxes/blob/master/scenarios/result_export/export_result_prallel.dig)
 
@@ -32,7 +32,7 @@ Note: http.authorization is used as header in your API request.
 You must http.authorization like this : ```TD1 <Your APIKey>```
 
 For detail, please refer to the below page.
-https://tddocs.atlassian.net/wiki/spaces/PD/overview
+https://docs.treasuredata.com/display/public/PD/Product+Documentation+Home
 
 
 Third, please set your other services' credentials by ```td wf secrets``` command.
@@ -45,7 +45,7 @@ $ td wf secret --project export_result_td --set tdTable // Tabale
 ```
 
 For detail, please refer to below page.
-https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
+https://docs.treasuredata.com/display/public/PD/Setting+Workflow+Secrets+from+the+Command+Line
 
 Finally, you can trigger the session manually.
 

--- a/scenarios/result_export/export_result_ftp/README.md
+++ b/scenarios/result_export/export_result_ftp/README.md
@@ -4,8 +4,8 @@ You can export result to Your FTP serber without running the same query.
 
 ## Note
 
-Using `td_result_export` operator is much easier and simpler for calling API by yourself.  
-If you want to know how to use `td_result_export`, please check the [Doc](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084693/Reference+for+Treasure+Data+Operators#td_result_export%3E%3A)  
+Using `td_result_export` operator is much easier and simpler for calling API by yourself.
+If you want to know how to use `td_result_export`, please check the [Doc](https://docs.treasuredata.com/display/public/PD/Reference+for+Treasure+Data+Operators#ReferenceforTreasureDataOperators-td_result_export%3E:)
 
 The sample is [here](https://github.com/treasure-data/treasure-boxes/blob/master/scenarios/result_export/export_result_prallel.dig)
 
@@ -23,7 +23,7 @@ Create a connection on console
 
 ![](https://t.gyazo.com/teams/treasure-data/55071234c2d489b7bb1bdbb342a067e0.png)
 
-Connection name is used in Workflow file 
+Connection name is used in Workflow file
 
 ## How to Run for Server/Client Mode
 First, please upload the workflow after making changes to the connection and filepath variable defined in `_export` section.
@@ -40,7 +40,7 @@ $ td wf secret --project export_result_ftp --set td.apikey
 ```
 
 For detail, please refer to the below page.
-https://tddocs.atlassian.net/wiki/spaces/PD/overview
+https://docs.treasuredata.com/display/public/PD/Product+Documentation+Home
 
 
 Finally, you can trigger the session manually.
@@ -51,5 +51,5 @@ $ td wf start export_result_ftp export_result_ftp --session now
 ```
 
 ## Next Step
-Further reading: https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081684/About+Using+Workflows+to+Export+Data+with+TD+Toolbelt#FTP-Result-Output-using-result_settings-Example
+Further reading: https://docs.treasuredata.com/display/public/PD/About+Using+Workflows+to+Export+Data+with+TD+Toolbelt#AboutUsingWorkflowstoExportDatawithTDToolbelt-FTPResultOutputusingresult_settingsExample
 If you have any questions, please contact to support@treasuredata.com.

--- a/scenarios/result_export/export_result_mongodb/README.md
+++ b/scenarios/result_export/export_result_mongodb/README.md
@@ -1,11 +1,11 @@
 # Workflow: export_result
-This example shows how use result_export API in Treasure Data workflow. 
+This example shows how use result_export API in Treasure Data workflow.
 You can export result to Your MongoDB without running the same query.
 
 ## Note
 
-Using `td_result_export` operator is much easier and simpler for calling API by yourself.  
-If you want to know how to use `td_result_export`, please check the [Doc](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084693/Reference+for+Treasure+Data+Operators#td_result_export%3E%3A)  
+Using `td_result_export` operator is much easier and simpler for calling API by yourself.
+If you want to know how to use `td_result_export`, please check the [Doc](https://docs.treasuredata.com/display/public/PD/Reference+for+Treasure+Data+Operators#ReferenceforTreasureDataOperators-td_result_export%3E:)
 
 The sample is [here](https://github.com/treasure-data/treasure-boxes/blob/master/scenarios/result_export/export_result_prallel.dig)
 
@@ -32,7 +32,7 @@ Note: http.authorization is used as header in your API request.
 You must http.authorization like this : ```TD1 <Your APIKey>```
 
 For detail, please refer to the below page.
-https://tddocs.atlassian.net/wiki/spaces/PD/overview
+https://docs.treasuredata.com/display/public/PD/Product+Documentation+Home
 
 
 Third, please set your other services' credentials by ```td wf secrets``` command.
@@ -47,7 +47,7 @@ $ td wf secret --project export_result_mongodb --set mongodbTable // RedShift Ta
 ```
 
 For detail, please refer to below page.
-https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
+https://docs.treasuredata.com/display/public/PD/Setting+Workflow+Secrets+from+the+Command+Line
 
 Finally, you can trigger the session manually.
 

--- a/scenarios/result_export/export_result_mysql/README.md
+++ b/scenarios/result_export/export_result_mysql/README.md
@@ -6,8 +6,8 @@ You can export result to Your MySQL without running the same query.
 
 ## Note
 
-Using `td_result_export` operator is much easier and simpler for calling API by yourself.  
-If you want to know how to use `td_result_export`, please check the [Doc](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084693/Reference+for+Treasure+Data+Operators#td_result_export%3E%3A)  
+Using `td_result_export` operator is much easier and simpler for calling API by yourself.
+If you want to know how to use `td_result_export`, please check the [Doc](https://docs.treasuredata.com/display/public/PD/Reference+for+Treasure+Data+Operators#ReferenceforTreasureDataOperators-td_result_export%3E:)
 
 The sample is [here](https://github.com/treasure-data/treasure-boxes/blob/master/scenarios/result_export/export_result_prallel.dig)
 
@@ -32,7 +32,7 @@ Note: http.authorization is used as header in your API request.
 You must http.authorization like this : ```TD1 <Your APIKey>```
 
 For detail, please refer to the below page.
-https://tddocs.atlassian.net/wiki/spaces/PD/overview
+https://docs.treasuredata.com/display/public/PD/Product+Documentation+Home
 
 
 Third, please set your other services' credentials by ```td wf secrets``` command.
@@ -47,7 +47,7 @@ $ td wf secret --project export_result_mysql --set mysqlTable // MySQL Table
 ```
 
 For detail, please refer to below page.
-https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
+https://docs.treasuredata.com/display/public/PD/Setting+Workflow+Secrets+from+the+Command+Line
 
 Finally, you can trigger the session manually.
 

--- a/scenarios/result_export/export_result_postgresql/README.md
+++ b/scenarios/result_export/export_result_postgresql/README.md
@@ -5,7 +5,7 @@ You can export result to Your PostgreSQL without running the same query.
 ## Note
 
 Using `td_result_export` operator is much easier and simpler for calling API by yourself.  
-If you want to know how to use `td_result_export`, please check the [Doc](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084693/Reference+for+Treasure+Data+Operators#td_result_export%3E%3A)  
+If you want to know how to use `td_result_export`, please check the [Doc](https://docs.treasuredata.com/display/public/PD/Reference+for+Treasure+Data+Operators#ReferenceforTreasureDataOperators-td_result_export%3E:)  
 
 The sample is [here](https://github.com/treasure-data/treasure-boxes/blob/master/scenarios/result_export/export_result_prallel.dig)
 
@@ -32,7 +32,7 @@ Note: http.authorization is used as header in your API request.
 You must http.authorization like this : ```TD1 <Your APIKey>```
 
 For detail, please refer to the below page.
-https://tddocs.atlassian.net/wiki/spaces/PD/overview
+https://docs.treasuredata.com/display/public/PD/Product+Documentation+Home
 
 
 Third, please set your other services' credentials by ```td wf secrets``` command.
@@ -47,7 +47,7 @@ $ td wf secret --project export_result_postgresql --set postgreTable // PostgreS
 ```
 
 For detail, please refer to below page.
-https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
+https://docs.treasuredata.com/display/public/PD/Setting+Workflow+Secrets+from+the+Command+Line
 
 Finally, you can trigger the session manually.
 

--- a/scenarios/result_export/export_result_redshift/README.md
+++ b/scenarios/result_export/export_result_redshift/README.md
@@ -4,8 +4,8 @@ You can export result to Your RedShift without running the same query.
 
 ## Note
 
-Using `td_result_export` operator is much easier and simpler for calling API by yourself.  
-If you want to know how to use `td_result_export`, please check the [Doc](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084693/Reference+for+Treasure+Data+Operators#td_result_export%3E%3A)  
+Using `td_result_export` operator is much easier and simpler for calling API by yourself.
+If you want to know how to use `td_result_export`, please check the [Doc](https://docs.treasuredata.com/display/public/PD/Reference+for+Treasure+Data+Operators#ReferenceforTreasureDataOperators-td_result_export%3E:)
 
 The sample is [here](https://github.com/treasure-data/treasure-boxes/blob/master/scenarios/result_export/export_result_prallel.dig)
 
@@ -32,7 +32,7 @@ Note: http.authorization is used as header in your API request.
 You must http.authorization like this : ```TD1 <Your APIKey>```
 
 For detail, please refer to the below page.
-https://tddocs.atlassian.net/wiki/spaces/PD/overview
+https://docs.treasuredata.com/display/public/PD/Product+Documentation+Home
 
 
 Third, please set your other services' credentials by ```td wf secrets``` command.
@@ -47,7 +47,7 @@ $ td wf secret --project export_result_redshift --set redshiftTable // RedShift 
 ```
 
 For detail, please refer to below page.
-https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
+https://docs.treasuredata.com/display/public/PD/Setting+Workflow+Secrets+from+the+Command+Line
 
 Finally, you can trigger the session manually.
 

--- a/scenarios/result_export/export_result_s3/README.md
+++ b/scenarios/result_export/export_result_s3/README.md
@@ -4,8 +4,8 @@ You can export result to Your S3 without running the same query.
 
 ## Note
 
-Using `td_result_export` operator is much easier and simpler for calling API by yourself.  
-If you want to know how to use `td_result_export`, please check the [Doc](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084693/Reference+for+Treasure+Data+Operators#td_result_export%3E%3A)  
+Using `td_result_export` operator is much easier and simpler for calling API by yourself.
+If you want to know how to use `td_result_export`, please check the [Doc](https://docs.treasuredata.com/display/public/PD/Reference+for+Treasure+Data+Operators#ReferenceforTreasureDataOperators-td_result_export%3E:)
 
 The sample is [here](https://github.com/treasure-data/treasure-boxes/blob/master/scenarios/result_export/export_result_prallel.dig)
 
@@ -32,7 +32,7 @@ Note: http.authorization is used as header in your API request.
 You must http.authorization like this : ```TD1 <Your APIKey>```
 
 For detail, please refer to the below page.
-https://tddocs.atlassian.net/wiki/spaces/PD/overview
+https://docs.treasuredata.com/display/public/PD/Product+Documentation+Home
 
 
 Third, please set your other services' credentials by ```td wf secrets``` command.
@@ -47,7 +47,7 @@ $ td wf secret --project export_result_example --set aws.s3.filepath
 
 
 For detail, please refer to below page.
-https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
+https://docs.treasuredata.com/display/public/PD/Setting+Workflow+Secrets+from+the+Command+Line
 
 Finally, you can trigger the session manually.
 

--- a/scenarios/result_export/export_result_tableau/README.md
+++ b/scenarios/result_export/export_result_tableau/README.md
@@ -1,11 +1,11 @@
 # Workflow: export_result
-This example shows how use result_export API in Treasure Data workflow. 
+This example shows how use result_export API in Treasure Data workflow.
 You can export result to Your Tableau without running the same query.
 
 ## Note
 
-Using `td_result_export` operator is much easier and simpler for calling API by yourself.  
-If you want to know how to use `td_result_export`, please check the [Doc](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084693/Reference+for+Treasure+Data+Operators#td_result_export%3E%3A)  
+Using `td_result_export` operator is much easier and simpler for calling API by yourself.
+If you want to know how to use `td_result_export`, please check the [Doc](https://docs.treasuredata.com/display/public/PD/Reference+for+Treasure+Data+Operators#ReferenceforTreasureDataOperators-td_result_export%3E:)
 
 The sample is [here](https://github.com/treasure-data/treasure-boxes/blob/master/scenarios/result_export/export_result_prallel.dig)
 
@@ -32,7 +32,7 @@ Note: http.authorization is used as header in your API request.
 You must http.authorization like this : ```TD1 <Your APIKey>```
 
 For detail, please refer to the below page.
-https://tddocs.atlassian.net/wiki/spaces/PD/overview
+https://docs.treasuredata.com/display/public/PD/Product+Documentation+Home
 
 
 Third, please set your other services' credentials by ```td wf secrets``` command.
@@ -47,7 +47,7 @@ $ td wf secret --project export_result_tableau --set tableauProject // Tabluau P
 ```
 
 For detail, please refer to below page.
-https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
+https://docs.treasuredata.com/display/public/PD/Setting+Workflow+Secrets+from+the+Command+Line
 
 Finally, you can trigger the session manually.
 

--- a/scenarios/run_token_api_after_master_segment/README.md
+++ b/scenarios/run_token_api_after_master_segment/README.md
@@ -11,7 +11,7 @@ This workflow checks if there is running master segment workflow or not. After f
 You have to change it if your account's site is located in EU or Tokyo.
 
 Please refer to the doc for more details.
-https://tddocs.atlassian.net/wiki/spaces/PD/pages/1085143/Sites+and+Endpoints
+https://docs.treasuredata.com/display/public/PD/Sites+and+Endpoints
 
 # How to Run
 First, upload the project.

--- a/td/another_td/README.md
+++ b/td/another_td/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to Another TD Account)
 
-This example workflow ingests data using [Treasure Data's Writing Job Results into TD Table)](https://docs.treasuredata.com/articles/result-into-td) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow ingests data using [Treasure Data's Writing Job Results into TD Table)](https://docs.treasuredata.com/display/public/INT/Treasure+Data+Data+Exchange+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
@@ -50,7 +50,7 @@ Available parameters for `result_settings` are here.
 - IDCF  : api.ybi.idcfcloud.net
 - AWS TOKYO: api.treasuredata.co.jp
 
-For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/articles/result-into-td#two-ways-to-modify-data-appendreplace)
+For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/display/public/INT/Treasure+Data+Data+Exchange+Export+Integration#TreasureDataDataExchangeExportIntegration-TwoWaystoModifyData)
 
 # Next Step
 

--- a/td/bigquery/README.md
+++ b/td/bigquery/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to BigQuery)
 
-This example workflow ingests data using [Treasure Data's Writing Job Results into Google BigQuery](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081809/Google+BigQuery+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow ingests data using [Treasure Data's Writing Job Results into Google BigQuery](https://docs.treasuredata.com/display/public/INT/Google+BigQuery+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
@@ -53,7 +53,7 @@ Available parameters for `result_settings` are here.
 - allow_quoted_newlines: (boolean, default false)
 - schema_file: (string(json), required)
 
-For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/articles/result-into-google-bigquery#use-from-cli)
+For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/display/public/INT/Google+BigQuery+Export+Integration)
 
 # Next Step
 

--- a/td/box/README.md
+++ b/td/box/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to Data Tanks)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Writing Job Results into BOX](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083770/Box+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Writing Job Results into BOX](https://docs.treasuredata.com/display/public/INT/Box+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # How to Run
 

--- a/td/datatank/README.md
+++ b/td/datatank/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to Data Tanks)
 
-This example workflow exports data to [Data Tanks](https://docs.treasuredata.com/articles/datatanks) using [Treasure Data's Writing Job Results into PostgreSQL Table)](https://docs.treasuredata.com/articles/result-into-postgresql) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow exports data to [Data Tanks](https://docs.treasuredata.com/display/public/PD/Data+Tanks+Using+Presto) using [Treasure Data's Writing Job Results into PostgreSQL Table)](https://docs.treasuredata.com/display/public/INT/PostgreSQL+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 Data Tanks is an add-on feature. Please contact Treasure Data Support if you're interested.
 

--- a/td/dbm/README.md
+++ b/td/dbm/README.md
@@ -1,6 +1,6 @@
 # Workflow: Result Output to DoubleClick Bid Manager
 
-This example workflow ingests data using [Writing Job Results into Google DoubleClick Bid Manager on the DoubleClick Data Platform](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082604/Google+DoubleClick+Bid+Manager+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow ingests data using [Writing Job Results into Google DoubleClick Bid Manager on the DoubleClick Data Platform](https://docs.treasuredata.com/display/public/INT/Google+DoubleClick+Bid+Manager+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
@@ -37,7 +37,7 @@ Available parameters for `result_settings` are here.
 - cookie_column_header: (string, required)
 - membership_lifespan: (int, optional)
 
-For more details, please see [Treasure Data documentation](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082604/Google+DoubleClick+Bid+Manager+Export+Integration)
+For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/display/public/INT/Google+DoubleClick+Bid+Manager+Export+Integration)
 
 # Next Step
 

--- a/td/elasticsearch/README.md
+++ b/td/elasticsearch/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to Elasticsearch)
 
-This example workflow exports TD job results into Elasticsearch, using [Treasure Data's Writing Job Results into Elasticsearch](https://docs.treasuredata.com/articles/result-into-elasticsearch) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow exports TD job results into Elasticsearch, using [Treasure Data's Writing Job Results into Elasticsearch](https://docs.treasuredata.com/display/public/INT/Elastic+Cloud+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
@@ -51,7 +51,7 @@ Available parameters for `result_settings` are here.
 - bulk_size: (long, default 5242880)
 - concurrent_requests: (int, default 5)
 
-For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/articles/result-into-elasticsearch).
+For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/display/public/INT/Elastic+Cloud+Export+Integration).
 
 # Result URL format
 

--- a/td/facebook_custom_audience/README.md
+++ b/td/facebook_custom_audience/README.md
@@ -1,10 +1,10 @@
 # Workflow: td example (Result Output to Facebook Custom Audience)
 
-This example workflow outputs data to a Facebook custom audience using [Writing Job Results into Facebook Custom Audience](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083108/Facebook+Custom+Audience+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow outputs data to a Facebook custom audience using [Writing Job Results into Facebook Custom Audience](https://docs.treasuredata.com/display/public/INT/Facebook+Custom+Audience+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
-In order to register your credential in Treasure Data, please create connection by following the instructions on this page [Writing Job Results into Facebook Custom Audience](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083108/Facebook+Custom+Audience+Export+Integration)
+In order to register your credential in Treasure Data, please create connection by following the instructions on this page [Writing Job Results into Facebook Custom Audience](https://docs.treasuredata.com/display/public/INT/Facebook+Custom+Audience+Export+Integration)
 
 The connection name is used in the dig file.
 
@@ -49,8 +49,8 @@ Available parameters for `result_settings` are here.
 - retryLimit: Number of times to retry on failure (int, optional, default: 5)
 
 
-For more details, please see [Treasure Data documentation (GUI)](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084846/Using+Workflow+from+TD+Console)
-or [Treasure Data documentation(CLI)](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083651/Treasure+Workflow+Quick+Start+using+TD+Toolbelt+in+a+CLI)
+For more details, please see [Treasure Data documentation (GUI)](https://docs.treasuredata.com/display/public/PD/Using+Workflow+from+TD+Console)
+or [Treasure Data documentation(CLI)](https://docs.treasuredata.com/display/public/PD/Treasure+Workflow+Quick+Start+using+TD+Toolbelt+in+a+CLI)
 
 # Next Step
 If you have any questions, please contact support@treasuredata.com.

--- a/td/ftp/README.md
+++ b/td/ftp/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to FTP(S))
 
-This example workflow ingests data in daily basis, using [Treasure Data's Writing Job Results into FTP(S)](https://docs.treasuredata.com/articles/result-into-ftp) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Writing Job Results into FTP(S)](https://docs.treasuredata.com/display/public/INT/FTP+Server+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
@@ -47,7 +47,7 @@ Available parameters for `result_settings` are here.
 - null_string: (string(""|"\N"|NULL|null), default "")
 - newline: (string(CRLF|CR|LF), default CRLF)
 
-For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/articles/result-into-ftp#usage-from-cli)
+For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/display/public/INT/FTP+Server+Export+Integration#FTPServerExportIntegration-UsagefromCLI)
 
 # Next Step
 

--- a/td/gcs/README.md
+++ b/td/gcs/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to Google Cloud Storage)
 
-This example workflow ingests data using [Treasure Data's Writing Job Results into Google Cloud Storage](https://tddocs.atlassian.net/wiki/spaces/PD/pages/4949333/Google+Cloud+Storage+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow ingests data using [Treasure Data's Writing Job Results into Google Cloud Storage](https://docs.treasuredata.com/display/public/INT/Google+Cloud+Storage+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
@@ -55,7 +55,7 @@ Available parameters for `result_settings` are here.
 - newline: (string(CRLF|CR|LF), default CRLF)
 - application_name: (string, Arbitrary client name associated with API requests)
 
-For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/articles/result-into-google-cloud-storage#use-from-cli)
+For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/display/public/INT/Exporting+Data+from+Google+Cloud+Storage+CLI)
 
 # Next Step
 

--- a/td/googleads_remarketing_lists/README.md
+++ b/td/googleads_remarketing_lists/README.md
@@ -1,10 +1,10 @@
 # Workflow: td example (Result Output to Google AdWords Remarketing Lists)
 
-This example workflow outputs data to a google adwords remarketing lists using [Writing Job Results into Google AdWords Remarketing Lists](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082644/Google+Ads+Remarketing+Lists+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow outputs data to a google adwords remarketing lists using [Writing Job Results into Google AdWords Remarketing Lists](https://docs.treasuredata.com/display/public/INT/Google+Ads+Remarketing+Lists+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
-In order to register your credential in Treasure Data, please create connection by following the instructions on this page [Writing Job Results into Google Adwords Remarketing Lists](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082644/Google+Ads+Remarketing+Lists+Export+Integration)
+In order to register your credential in Treasure Data, please create connection by following the instructions on this page [Writing Job Results into Google Adwords Remarketing Lists](https://docs.treasuredata.com/display/public/INT/Google+Ads+Remarketing+Lists+Export+Integration)
 
 The connection name is used in the dig file.
 
@@ -51,8 +51,8 @@ Available parameters for `result_settings` are here.
 - maximum_retry_interval_millis : Max retry wait in milliseconds. (int, optional, default: 300000)
 
 
-For more details, please see [Treasure workflow documentation (GUI)](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084846/Using+Workflow+from+TD+Console)
-or [Treasure workflow documentation (CLI)](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1672953/Using+TD+Workflow+from+the+Command+Line)
+For more details, please see [Treasure workflow documentation (GUI)](https://docs.treasuredata.com/display/public/PD/Using+Workflow+from+TD+Console)
+or [Treasure workflow documentation (CLI)](https://docs.treasuredata.com/display/public/PD/Using+TD+Workflow+from+the+Command+Line)
 
 # Next Step
 If you have any questions, please contact support@treasuredata.com.

--- a/td/gsheet/README.md
+++ b/td/gsheet/README.md
@@ -5,7 +5,7 @@ This example workflow exports TD job results into a Google Sheets with [td](http
 # Prerequisites
 
 You need to create a new Authentication for Google Sheets in advance.
-Please refer to the section '2. Account authentication' in the [Treasure Data Documentation](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081625/Google+Sheets+Export+Integration) in order to find the procedure.
+Please refer to the section '2. Account authentication' in the [Treasure Data Documentation](https://docs.treasuredata.com/display/public/INT/Google+Sheets+Export+Integration) in order to find the procedure.
 
 The connection name is used in the dig file.
 
@@ -55,7 +55,7 @@ Available parameters for `result_settings` are here.
 
 **※You must choose to use either the *****spreadsheet_id***** OR *****spreadsheet_title.***** You cannot use both.**
 
-For more details, please see [Treasure Data documentation](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081625/Google+Sheets+Export+Integration)
+For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/display/public/INT/Google+Sheets+Export+Integration)
 
 # Next Step
 

--- a/td/mailchimp/README.md
+++ b/td/mailchimp/README.md
@@ -2,7 +2,7 @@
 
 [Our blog post](https://blog.treasuredata.com/blog/2016/08/31/increase-customer-engagement-with-mailchimp/) describes an importance of customer engagement with Mailchimp and Treasure Data
 
-This example workflow gives you an overview and directions on how to build personalized email lists on Mailchimp using [Treasure Data's Result Output to Mailchimp](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081611/Mailchimp+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow gives you an overview and directions on how to build personalized email lists on Mailchimp using [Treasure Data's Result Output to Mailchimp](https://docs.treasuredata.com/display/public/INT/Mailchimp+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 In order to register your credential in TreasureData, please create connection setting on [Connector UI](https://console.treasuredata.com/app/connections).
 
@@ -56,7 +56,7 @@ Available parameters for `result_settings` are here.
 - retry_initial_wait_msec: (int, default 1000)
 - max_retry_wait_msec: (int, default 32000)
 
-For more details, please see [Treasure Data documentation](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081611/Mailchimp+Export+Integration)
+For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/display/public/INT/Mailchimp+Export+Integration)
 
 # Next Step
 

--- a/td/marketo/README.md
+++ b/td/marketo/README.md
@@ -1,11 +1,11 @@
 # Workflow: td example (Result Output to Marketo)
 
-This example workflow exports TD job results into Marketo [Treasure Data's Writing Job Results into Marketo](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081744/Marketo+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow exports TD job results into Marketo [Treasure Data's Writing Job Results into Marketo](https://docs.treasuredata.com/display/public/INT/Marketo+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
 The Marketo connection name is required for use in the workflow file.
-Create a new Marketo Connection using [Create Connection](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081744/Marketo+Export+Integration#Create-a-New-Connection) or use your existing connection.
+Create a new Marketo Connection using [Create Connection](https://docs.treasuredata.com/display/public/INT/Marketo+Export+Integration#Create-a-New-Connection) or use your existing connection.
 
 
 # How to Run
@@ -41,7 +41,7 @@ Available parameters for `result_settings` are here.
 - upload_chunk_size_in_bytes: Max upload chunk size in bytes (integer, optional)
 - batch_max_wait_msec: Batch max wait in milliseconds (integer, optional)
 
-For more details on Result output to Marketo, please see [Treasure Data documentation](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081744/Marketo+Export+Integration)
+For more details on Result output to Marketo, please see [Treasure Data documentation](https://docs.treasuredata.com/display/public/INT/Marketo+Export+Integration)
 
 # Next Step
 

--- a/td/microsoft-azure-blob-storage/README.md
+++ b/td/microsoft-azure-blob-storage/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to Microsoft Azure Blob Storage)
 
-This example workflow exports TD job results into Microsoft Azure Blob Storage, using [Treasure Data's Writing Job Results into Microsoft Azure Blob Storage](https://docs.treasuredata.com/articles/result-into-microsoft-azure-blob-storage) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow exports TD job results into Microsoft Azure Blob Storage, using [Treasure Data's Writing Job Results into Microsoft Azure Blob Storage](https://docs.treasuredata.com/display/public/INT/Microsoft+Azure+Blob+Storage+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
@@ -53,7 +53,7 @@ Available parameters for `result_settings` are here.
 - null_string: (string(""|"\N"|NULL|null), default "")
 - new_line: (string(CRLF|CR|LF), default CRLF)
 
-For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/articles/result-into-microsoft-azure-blob-storage)
+For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/display/public/INT/Microsoft+Azure+Blob+Storage+Export+Integration)
 
 # Next Step
 

--- a/td/microsoft-sql-server/README.md
+++ b/td/microsoft-sql-server/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to Microsoft SQL Server)
 
-This example workflow exports TD job results into SQL Server, using [Treasure Data's Writing Job Results into SQL Server tables](https://docs.treasuredata.com/articles/result-into-microsoft-sql-server) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow exports TD job results into SQL Server, using [Treasure Data's Writing Job Results into SQL Server tables](https://docs.treasuredata.com/display/public/INT/Microsoft+SQL+Server+Tables+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
@@ -55,7 +55,7 @@ Available parameters for `result_settings` are here.
 - If you are using Azure, omit the instance name and provide the port # only.
 - If you are not using Azure and want to use your own instance: please make sure that you can connect to the database using only the instance name, without the port. If the instance name does not work, you have to set the correct port instead of instance.
 
-For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/articles/result-into-microsoft-sql-server)
+For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/display/public/INT/Microsoft+SQL+Server+Tables+Export+Integration)
 
 # Next Step
 

--- a/td/mongodb/README.md
+++ b/td/mongodb/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to MongoDB)
 
-This example workflow exports TD job results into MongoDB, using [Treasure Data's Writing Job Results into your Mongodb Collections](https://docs.treasuredata.com/articles/result-into-mongodb) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow exports TD job results into MongoDB, using [Treasure Data's Writing Job Results into your Mongodb Collections](https://docs.treasuredata.com/display/public/INT/MongoDB+Collections+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
@@ -48,7 +48,7 @@ Available parameters for `result_settings` are here.
 - mode: (string(append|replace|truncate|update), default append)
 - unique: (string, available for update mode)
 
-For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/articles/result-into-mongodb).
+For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/display/public/INT/MongoDB+Collections+Export+Integration).
 
 # Next Step
 

--- a/td/mysql/README.md
+++ b/td/mysql/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to MySQL)
 
-This example workflow ingests data using [Treasure Data's Writing Job Results into MySQL Table)](https://docs.treasuredata.com/articles/result-into-mysql) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow ingests data using [Treasure Data's Writing Job Results into MySQL Table](https://docs.treasuredata.com/display/public/INT/MySQL+Tables+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
@@ -50,7 +50,7 @@ Available parameters for `result_settings` are here.
 - unique: (string, available for update mode)
 - use_compression: (boolean, default false)
 
-For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/articles/result-into-mysql#four-modes-to-modify-data-appendreplacetruncateupdate)
+For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/display/public/INT/MySQL+Tables+Export+Integration#MySQLTablesExportIntegration-SetTransferSettings)
 
 # Next Step
 

--- a/td/nend/README.md
+++ b/td/nend/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to nend)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Writing Job Results into nend](https://docs.treasuredata.com/articles/iresult-into-nend) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Writing Job Results into nend](https://docs.treasuredata.com/display/public/INT/nend+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
@@ -49,7 +49,7 @@ Available parameters for `result_settings` are here.
 - retry_limit: (integer, default 4)
 - mode: (string(append|replace), default replace)
 
-For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/articles/result-into-nend)
+For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/display/public/INT/nend+Export+Integration)
 
 # Next Step
 

--- a/td/postgresql/README.md
+++ b/td/postgresql/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to PostgreSQL)
 
-This example workflow ingests data using [Treasure Data's Writing Job Results into PostgreSQL Table)](https://docs.treasuredata.com/articles/result-into-postgresql) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow ingests data using [Treasure Data's Writing Job Results into PostgreSQL Table](https://docs.treasuredata.com/display/public/INT/PostgreSQL+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
@@ -38,7 +38,7 @@ You can trigger the session manually.
 
     # Run
     $ td wf run td_postgresql.dig
-    
+
 # Supplemental
 
 Available parameters for `result_settings` are here.
@@ -51,7 +51,7 @@ Available parameters for `result_settings` are here.
 - schema: (string, optional)
 - fdw: (string(None|cstore), default None)
 
-For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/articles/result-into-postgresql#result-output-url-format)
+For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/display/public/INT/PostgreSQL+Export+Integration#result-output-url-format)
 
 # Next Step
 

--- a/td/redshift/README.md
+++ b/td/redshift/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to Redshift)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Writing Job Results into AWS Redshift](https://docs.treasuredata.com/articles/result-into-redshift) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Writing Job Results into AWS Redshift](https://docs.treasuredata.com/display/public/INT/Amazon+Redshift+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
@@ -49,7 +49,7 @@ Available parameters for `result_settings` are here.
 - unique: (string, available for update mode)
 - schema: (string, optional)
 
-For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/articles/result-into-redshift)
+For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/display/public/INT/Amazon+Redshift+Export+Integration)
 
 # Next Step
 

--- a/td/s3/README.md
+++ b/td/s3/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to s3)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Writing Job Results into AWS S3](https://docs.treasuredata.com/articles/result-into-s3) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Writing Job Results into AWS S3](https://docs.treasuredata.com/display/public/INT/Amazon+S3+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
@@ -54,7 +54,7 @@ Available parameters for `result_settings` are here.
 - quote: (string, optional)
 - escape: (string, optional)
 
-For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/articles/result-into-s3#usage)
+For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/display/public/INT/Amazon+S3+Export+Integration#usage)
 
 # Next Step
 

--- a/td/salesforce_marketing_cloud_exacttarget/README.md
+++ b/td/salesforce_marketing_cloud_exacttarget/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to Salesforce Marketing Cloud (ExactTarget))
 
-This example workflow ingests data in daily basis, using [Treasure Data's Writing Job Results into Salesforce Marketing Cloud (ExactTarget)](https://docs.treasuredata.com/articles/result-into-salesforce-marketing-cloud) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Writing Job Results into Salesforce Marketing Cloud (ExactTarget)](https://docs.treasuredata.com/display/public/INT/Salesforce+Marketing+Cloud+ExactTarget+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
@@ -53,7 +53,7 @@ Available parameters for `result_settings` are here.
 - null_string: (string(""|"\N"|NULL|null), default "")
 - newline: (string(CRLF|CR|LF), default CRLF)
 
-For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/articles/result-into-salesforce-marketing-cloud#run-a-treasure-data-job-to-complete-an-initial-import-to-salesforce)
+For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/display/public/INT/Salesforce+Marketing+Cloud+ExactTarget+Export+Integration+Using+CLI)
 
 # Next Step
 

--- a/td/sfdc/README.md
+++ b/td/sfdc/README.md
@@ -1,11 +1,11 @@
 # Workflow: td example (Result Output to Salesforce)
 
-This example workflow exports TD job results into Salesforce [Treasure Data's Writing Job Results into Salesforce](https://docs.treasuredata.com/articles/result-into-salesforce) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow exports TD job results into Salesforce [Treasure Data's Writing Job Results into Salesforce](https://docs.treasuredata.com/display/public/INT/Salesforce+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
 Salesforce.com organization and username, password, and security token for API integration
-https://docs.treasuredata.com/articles/result-into-salesforce#prerequisites
+https://docs.treasuredata.com/display/public/INT/Salesforce+Export+Integration#SalesforceExportIntegration-Prerequisites
 
 ![](https://t.gyazo.com/teams/treasure-data/0153ad6cb81d8a2ca71d3c55fe6c21e1.png)
 
@@ -53,7 +53,7 @@ Available parameters for `result_settings` are here.
 - retry: (integer, default 2)
 - split_records: (integer, default 10000)
 
-For more details on Result output to Salesforce, please see [Treasure Data documentation](https://docs.treasuredata.com/articles/result-into-salesforce)
+For more details on Result output to Salesforce, please see [Treasure Data documentation](https://docs.treasuredata.com/display/public/INT/Salesforce+Export+Integration)
 
 # Next Step
 

--- a/td/sftp/README.md
+++ b/td/sftp/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to SFTP)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Writing Job Results into SFTP](https://docs.treasuredata.com/articles/result-into-sftp) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Writing Job Results into SFTP](https://docs.treasuredata.com/display/public/INT/SFTP+Server+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
@@ -53,7 +53,7 @@ Available parameters for `result_settings` are here.
 - null_string: (string(""|"\N"|NULL|null), default "")
 - newline: (string(CRLF|CR|LF), default CRLF)
 
-For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/articles/result-into-sftp#usage-from-cli)
+For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/display/public/INT/SFTP+Server+Export+Integration#SFTPServerExportIntegration-UsagefromCLI)
 
 # Next Step
 

--- a/td/tableau/README.md
+++ b/td/tableau/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to Tableau)
 
-This example workflow ingests data using [Tableau Server with Treasure Data](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082963/Tableau+Server+Export+Integration) or [Tableau Online with Treasure Data](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081683/Tableau+Online+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow ingests data using [Tableau Server with Treasure Data](https://docs.treasuredata.com/display/public/INT/Tableau+Server+Export+Integration) or [Tableau Online with Treasure Data](https://docs.treasuredata.com/display/public/INT/Tableau+Online+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 

--- a/td/twitter_tailored_audience/README.md
+++ b/td/twitter_tailored_audience/README.md
@@ -1,10 +1,10 @@
 # Workflow: td example (Result Output to Twitter Tailored Audience)
 
-This example workflow outputs data to a twitter tailorerd audience using [Writing Job Results into your Twitter Tailored Audience](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081589/Twitter+Tailored+Audience+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow outputs data to a twitter tailorerd audience using [Writing Job Results into your Twitter Tailored Audience](https://docs.treasuredata.com/display/public/INT/Twitter+Tailored+Audience+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
-In order to register your credential in Treasure Data, please create connection by following the instructions on this page [Writing Job Results into your Twitter Tailored Audience](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081589/Twitter+Tailored+Audience+Export+Integration)
+In order to register your credential in Treasure Data, please create connection by following the instructions on this page [Writing Job Results into your Twitter Tailored Audience](https://docs.treasuredata.com/display/public/INT/Twitter+Tailored+Audience+Export+Integration)
 
 The connection name is used in the dig file.
 
@@ -48,8 +48,8 @@ Available parameters for `result_settings` are here.
 - max_retry_wait_msec: Maximum time in milliseconds between retrying attempts. (int, optional, default: 320000)
 
 
-For more details, please see [Treasure Data documentation (GUI)](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1084846/Using+Workflow+from+TD+Console)
-or [Treasure Data documentation(CLI)](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083651/Treasure+Workflow+Quick+Start+using+TD+Toolbelt+in+a+CLI)
+For more details, please see [Treasure Data documentation (GUI)](https://docs.treasuredata.com/display/public/PD/Using+Workflow+from+TD+Console)
+or [Treasure Data documentation(CLI)](https://docs.treasuredata.com/display/public/PD/Treasure+Workflow+Quick+Start+using+TD+Toolbelt+in+a+CLI)
 
 # Next Step
 If you have any questions, please contact support@treasuredata.com.

--- a/td/web_server/README.md
+++ b/td/web_server/README.md
@@ -1,6 +1,6 @@
 # Workflow: td example (Result Output to Web Server)
 
-This example workflow ingests data using [Treasure Data's Writing Job Results into Web Server)](https://docs.treasuredata.com/articles/result-into-web) with [td](https://docs.digdag.io/operators/td.html) operator.
+This example workflow ingests data using [Treasure Data's Writing Job Results into Web Server)](https://docs.treasuredata.com/display/public/INT/Web+Server+and+HTTP+PUT+Endpoint+Export+Integration) with [td](https://docs.digdag.io/operators/td.html) operator.
 
 # Prerequisites
 
@@ -45,7 +45,7 @@ Available parameters for `result_settings` are here.
 
 - path: (string, required)
 
-For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/articles/result-into-web#for-on-demand-jobs)
+For more details, please see [Treasure Data documentation](https://docs.treasuredata.com/display/public/INT/Web+Server+and+HTTP+PUT+Endpoint+Export+Integration#WebServerandHTTPPUTEndpointExportIntegration-ForOn-DemandJobs)
 
 # Next Step
 

--- a/td_load/amplitude/README.md
+++ b/td_load/amplitude/README.md
@@ -1,8 +1,8 @@
 # Workflow: td_load Example (Amplitude)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Amplitude](https://docs.treasuredata.com/articles/data-connector-amplitude) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Amplitude](https://docs.treasuredata.com/display/public/INT/Amplitude+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
-The workflow also uses [Secrets](https://docs.treasuredata.com/articles/workflows-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
+The workflow also uses [Secrets](https://docs.treasuredata.com/display/public/PD/Workflows+and+Machine+Learning-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
 
 # How to Run
 

--- a/td_load/azure_blob_storage/README.md
+++ b/td_load/azure_blob_storage/README.md
@@ -1,8 +1,8 @@
 # Workflow: td_load Example (Microsoft Azure Blob Storage)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Microsoft Azure Blob Storage](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081764/Microsoft+Azure+Blob+Storage+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Microsoft Azure Blob Storage](https://docs.treasuredata.com/display/public/INT/Microsoft+Azure+Blob+Storage+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
-The workflow also uses [Secrets](https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line) feature, so that you don't have to include your datasource credentials to your workflow files.
+The workflow also uses [Secrets](https://docs.treasuredata.com/display/public/PD/Setting+Workflow+Secrets+from+the+Command+Line) feature, so that you don't have to include your datasource credentials to your workflow files.
 
 # How to Run
 

--- a/td_load/azure_blob_storage/config/daily_load.yml
+++ b/td_load/azure_blob_storage/config/daily_load.yml
@@ -1,5 +1,5 @@
 # For more advanced config options, please check these URLs.
-# @see https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081764/Microsoft+Azure+Blob+Storage+Import+Integration
+# @see https://docs.treasuredata.com/display/public/INT/Microsoft+Azure+Blob+Storage+Import+Integration
 # @see https://github.com/embulk/embulk-input-azure_blob_storage
 ---
 in:

--- a/td_load/bigquery/README.md
+++ b/td_load/bigquery/README.md
@@ -1,5 +1,5 @@
 # Workflow: td_load example (Google BigQuery)
-This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Google BigQuery](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081348/Google+BigQuery+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Google BigQuery](https://docs.treasuredata.com/display/public/INT/Google+BigQuery+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
 # How to Run for Server Mode
 First, please upload the workflow. `bigquery` is the project name.

--- a/td_load/ftp/README.md
+++ b/td_load/ftp/README.md
@@ -1,8 +1,8 @@
 # Workflow: td_load Example (FTP(S))
 
-This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for FTP](https://docs.treasuredata.com/articles/data-connector-ftp) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for FTP](https://docs.treasuredata.com/display/public/INT/FTP+Server+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
-The workflow also uses [Secrets](https://docs.treasuredata.com/articles/workflows-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
+The workflow also uses [Secrets](https://docs.treasuredata.com/display/public/PD/Workflows+and+Machine+Learning-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
 
 # How to Run
 

--- a/td_load/gcs/README.md
+++ b/td_load/gcs/README.md
@@ -1,8 +1,8 @@
 # Workflow: td_load example (Google Cloud Storage)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Google Cloud Storage](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1082555/Google+Cloud+Storage+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Google Cloud Storage](https://docs.treasuredata.com/display/public/INT/Google+Cloud+Storage+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
-The workflow also uses [Secrets](https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line) feature, so that you don't have to include your database credentials to your workflow files.
+The workflow also uses [Secrets](https://docs.treasuredata.com/display/public/PD/Setting+Workflow+Secrets+from+the+Command+Line) feature, so that you don't have to include your database credentials to your workflow files.
 
 # How to Run for Local Mode
 

--- a/td_load/google_analytics/README.md
+++ b/td_load/google_analytics/README.md
@@ -1,8 +1,8 @@
 # Workflow: td_load Example (Google Analytics)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Google Analytics](https://docs.treasuredata.com/articles/data-connector-google-analytics) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Google Analytics](https://docs.treasuredata.com/display/public/INT/Google+Analytics+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
-The workflow also uses [Secrets](https://docs.treasuredata.com/articles/workflows-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
+The workflow also uses [Secrets](https://docs.treasuredata.com/display/public/PD/Workflows+and+Machine+Learning-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
 
 # How to Run
 

--- a/td_load/google_sheet/README.md
+++ b/td_load/google_sheet/README.md
@@ -2,7 +2,7 @@
 
 This example workflow ingests data from Google Sheet in daily basis.
 
-The workflow also uses [Secrets](https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line) feature, so that you don't have to include your datasource credentials to your workflow files.
+The workflow also uses [Secrets](https://docs.treasuredata.com/display/public/PD/Setting+Workflow+Secrets+from+the+Command+Line) feature, so that you don't have to include your datasource credentials to your workflow files.
 
 
 # How to Run
@@ -14,7 +14,7 @@ First, you can upload the workflow.
 
 Second, please set datasource credentials by `td wf secrets` command.
 (Alternatively you can use Web console to register secrets)
-https://tddocs.atlassian.net/wiki/spaces/PD/pages/219185771/Setting+Workflow+Secrets+from+TD+Console
+https://docs.treasuredata.com/display/public/PD/Setting+Workflow+Secrets+from+TD+Console
 
     # Set Secrets
     $ td wf secrets --project td_load_example --set gsheet.client_id

--- a/td_load/google_sheet/config/daily_load.yml
+++ b/td_load/google_sheet/config/daily_load.yml
@@ -15,7 +15,7 @@ in:
     value_render_option: FORMATTED_VALUE
     datetime_render_option: FORMATTED_STRING
     key: spreadsheet_key_here
-    # https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081625/Google+Sheets+Export+Integration#Find-the-Spreadsheet-Key
+    # https://docs.treasuredata.com/display/public/INT/Google+Sheets+Export+Integration#Find-the-Spreadsheet-Key
     
     null_string: '\N'
     default_typecast: strict

--- a/td_load/instagram_user_and_media_insights/README.md
+++ b/td_load/instagram_user_and_media_insights/README.md
@@ -1,6 +1,6 @@
 # Workflow: Instagram User and Media Insights
 
-This is example workflow ingests insights, using [Treasure Data's Data Connector for Instagram User and Media Insights](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081577/Instagram+User+and+Media+Insights+Import+Integration) with [`td_load`](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This is example workflow ingests insights, using [Treasure Data's Data Connector for Instagram User and Media Insights](https://docs.treasuredata.com/display/public/INT/Instagram+User+and+Media+Insights+Import+Integration) with [`td_load`](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
 ## Prerequisites
 

--- a/td_load/marketo/README.md
+++ b/td_load/marketo/README.md
@@ -1,8 +1,8 @@
 # Workflow: td_load Example (Marketo)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Marketo](https://docs.treasuredata.com/articles/data-connector-marketo) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Marketo](https://docs.treasuredata.com/display/public/INT/Marketo+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
-The workflow also uses [Secrets](https://docs.treasuredata.com/articles/workflows-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
+The workflow also uses [Secrets](https://docs.treasuredata.com/display/public/PD/Workflows+and+Machine+Learning-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
 
 # How to Run
 

--- a/td_load/mixpanel/README.md
+++ b/td_load/mixpanel/README.md
@@ -1,8 +1,8 @@
 # Workflow: td_load Example (Mixpanel)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Mixpanel](https://docs.treasuredata.com/articles/data-connector-mixpanel) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Mixpanel](https://docs.treasuredata.com/display/public/INT/Mixpanel+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
-The workflow also uses [Secrets](https://docs.treasuredata.com/articles/workflows-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
+The workflow also uses [Secrets](https://docs.treasuredata.com/display/public/PD/Workflows+and+Machine+Learning-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
 
 # How to Run
 

--- a/td_load/mysql/README.md
+++ b/td_load/mysql/README.md
@@ -1,8 +1,8 @@
 # Workflow: td_load example (MySQL)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for MySQL](https://docs.treasuredata.com/articles/data-connector-mysql) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for MySQL](https://docs.treasuredata.com/display/public/INT/MySQL+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
-The workflow also uses [Secrets](https://docs.treasuredata.com/articles/workflows-secrets) feature, so that you don't have to include your database credentials to your workflow files.
+The workflow also uses [Secrets](https://docs.treasuredata.com/display/public/PD/Workflows+and+Machine+Learning-secrets) feature, so that you don't have to include your database credentials to your workflow files.
 
 # How to Run
 

--- a/td_load/mysql/config/daily_load.yml
+++ b/td_load/mysql/config/daily_load.yml
@@ -1,5 +1,5 @@
 # For more advanced config options, please check these URLs.
-# @see https://docs.treasuredata.com/articles/data-connector-mysql
+# @see https://docs.treasuredata.com/display/public/INT/MySQL+Import+Integration
 # @see https://github.com/embulk/embulk-input-jdbc/tree/master/embulk-input-mysql
 ---
 in:

--- a/td_load/netsuite/README.md
+++ b/td_load/netsuite/README.md
@@ -1,8 +1,8 @@
 # Workflow: td_load Example (NetSuite)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for NetSuite](https://docs.treasuredata.com/articles/data-connector-netsuite) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for NetSuite](https://docs.treasuredata.com/display/public/INT/Netsuite+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
-The workflow also uses [Secrets](https://docs.treasuredata.com/articles/workflows-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
+The workflow also uses [Secrets](https://docs.treasuredata.com/display/public/PD/Workflows+and+Machine+Learning-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
 
 # How to Run
 

--- a/td_load/postgresql/README.md
+++ b/td_load/postgresql/README.md
@@ -1,8 +1,8 @@
 # Workflow: td_load example (PostgreSQL)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for PostgreSQL](https://docs.treasuredata.com/articles/data-connector-postgresql) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for PostgreSQL](https://docs.treasuredata.com/display/public/INT/PostgreSQL+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
-The workflow also uses [Secrets](https://docs.treasuredata.com/articles/workflows-secrets) feature, so that you don't have to include your database credentials to your workflow files.
+The workflow also uses [Secrets](https://docs.treasuredata.com/display/public/PD/Workflows+and+Machine+Learning-secrets) feature, so that you don't have to include your database credentials to your workflow files.
 
 # How to Run
 

--- a/td_load/postgresql/config/daily_load.yml
+++ b/td_load/postgresql/config/daily_load.yml
@@ -1,5 +1,5 @@
 # For advanced config options, please check these URLs.
-# @see https://docs.treasuredata.com/articles/data-connector-postgresql
+# @see https://docs.treasuredata.com/display/public/INT/PostgreSQL+Import+Integration
 # @see https://github.com/embulk/embulk-input-jdbc/tree/master/embulk-input-postgresql
 ---
 in:

--- a/td_load/s3/README.md
+++ b/td_load/s3/README.md
@@ -1,8 +1,8 @@
 # Workflow: td_load Example (Amazon S3)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Amazon S3](https://docs.treasuredata.com/articles/data-connector-s3) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Amazon S3](https://docs.treasuredata.com/display/public/INT/Amazon+S3+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
-The workflow also uses [Secrets](https://docs.treasuredata.com/articles/workflows-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
+The workflow also uses [Secrets](https://docs.treasuredata.com/display/public/PD/Workflows+and+Machine+Learning-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
 
 # How to Run
 

--- a/td_load/s3/config/daily_load.yml
+++ b/td_load/s3/config/daily_load.yml
@@ -1,5 +1,5 @@
 # For more advanced config options, please check these URLs.
-# @see https://docs.treasuredata.com/articles/data-connector-amazon-s3
+# @see https://docs.treasuredata.com/display/public/INT/Amazon+S3+Import+Integration
 # @see https://github.com/embulk/embulk-input-s3
 ---
 in:

--- a/td_load/sfdc/README.md
+++ b/td_load/sfdc/README.md
@@ -1,8 +1,8 @@
 # Workflow: td_load Example (SFDC)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Salesforce](https://docs.treasuredata.com/articles/data-connector-salesforce) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Salesforce](https://docs.treasuredata.com/display/public/INT/Salesforce+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
-The workflow also uses [Secrets](https://docs.treasuredata.com/articles/workflows-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
+The workflow also uses [Secrets](https://docs.treasuredata.com/display/public/PD/Workflows+and+Machine+Learning-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
 
 # How to Run
 

--- a/td_load/sfmc/README.md
+++ b/td_load/sfmc/README.md
@@ -1,8 +1,8 @@
 # Workflow: td_load Example (Salesforce Marketing Cloud)
 
-This example workflow ingests data in daily basis incrementally and fetches data from yesterday for 1 day, using [Treasure Data's Data Connector for SFMC](https://docs.treasuredata.com/articles/data-connector-salesforce-marketing-cloud) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This example workflow ingests data in daily basis incrementally and fetches data from yesterday for 1 day, using [Treasure Data's Data Connector for SFMC](https://docs.treasuredata.com/display/public/INT/Salesforce+Import+Integration-marketing-cloud) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
-The workflow also uses [Secrets](https://docs.treasuredata.com/articles/workflows-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
+The workflow also uses [Secrets](https://docs.treasuredata.com/display/public/PD/Workflows+and+Machine+Learning-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
 
 # How to Run
 

--- a/td_load/sftp/README.md
+++ b/td_load/sftp/README.md
@@ -1,8 +1,8 @@
 # Workflow: td_load Example (SFTP)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for SFTP](https://docs.treasuredata.com/articles/data-connector-sftp) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for SFTP](https://docs.treasuredata.com/display/public/INT/SFTP+Server+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
-The workflow also uses [Secrets](https://docs.treasuredata.com/articles/workflows-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
+The workflow also uses [Secrets](https://docs.treasuredata.com/display/public/PD/Workflows+and+Machine+Learning-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
 
 # How to Run
 

--- a/td_load/shopify/README.md
+++ b/td_load/shopify/README.md
@@ -1,8 +1,8 @@
 # Workflow: td_load Example (Shopify)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Shopify](https://docs.treasuredata.com/articles/data-connector-shopify) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Shopify](https://docs.treasuredata.com/display/public/INT/Shopify+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
-The workflow also uses [Secrets](https://docs.treasuredata.com/articles/workflows-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
+The workflow also uses [Secrets](https://docs.treasuredata.com/display/public/PD/Workflows+and+Machine+Learning-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
 
 # How to Run
 

--- a/td_load/sql_server/README.md
+++ b/td_load/sql_server/README.md
@@ -1,13 +1,13 @@
 # Workflow: td_load example (Microsoft SQL Server)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Microsoft SQL Server](https://docs.treasuredata.com/articles/data-connector-microsoft-sql-server) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Microsoft SQL Server](https://docs.treasuredata.com/display/public/INT/Microsoft+SQL+Server+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
 # Register Data Connector Job
 
 Data Connector for Microsoft SQL Server supports incremental mode using incremental_columns. If you want to use it, you have to register Connector Job without schedule.
 
 
-First, please prepare the load.yml refer to [Treasure Data's Data Connector for Microsoft SQL Server](https://docs.treasuredata.com/articles/data-connector-microsoft-sql-server).
+First, please prepare the load.yml refer to [Treasure Data's Data Connector for Microsoft SQL Server](https://docs.treasuredata.com/display/public/INT/Microsoft+SQL+Server+Import+Integration).
 
 Please note the following conditions in regard to connection setting:
 - If you are using Azure, omit the instance name and provide the port # only.
@@ -15,7 +15,7 @@ Please note the following conditions in regard to connection setting:
 
 - Sample of [load.yml](load.yml)
 
-Second, please register it without schedule. ([Create the schedule](https://docs.treasuredata.com/articles/data-connector-microsoft-sql-server#create-the-schedule))
+Second, please register it without schedule. ([Create the schedule](https://docs.treasuredata.com/display/public/INT/Microsoft+SQL+Server+Import+Integration#MicrosoftSQLServerImportIntegration-Scheduledexecution))
 
     # Sample Command
     td connector:create connector_job_name "" dest_db dest_table load.yml

--- a/td_load/zendesk/README.md
+++ b/td_load/zendesk/README.md
@@ -1,8 +1,8 @@
 # Workflow: td_load Example (Zendesk)
 
-This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Zendesk](https://docs.treasuredata.com/articles/data-connector-zendesk) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
+This example workflow ingests data in daily basis, using [Treasure Data's Data Connector for Zendesk](https://docs.treasuredata.com/display/public/INT/Zendesk+Import+Integration) with [td_load](https://docs.digdag.io/operators.html#td-load-treasure-data-bulk-loading) operator.
 
-The workflow also uses [Secrets](https://docs.treasuredata.com/articles/workflows-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
+The workflow also uses [Secrets](https://docs.treasuredata.com/display/public/PD/Workflows+and+Machine+Learning-secrets) feature, so that you don't have to include your datasource credentials to your workflow files.
 
 # How to Run
 

--- a/tool-box/audit-log-detection-samples/README.md
+++ b/tool-box/audit-log-detection-samples/README.md
@@ -47,5 +47,5 @@ This file is a workflow to run all the task above. When trying it, please set fo
 |secret:td.apikey | 1/xxxx |
 
 ### Documents
-- [Premium Audit Log Events](https://tddocs.atlassian.net/wiki/spaces/PD/pages/233734195/Premium+Audit+Log+Events)
-- [Premium Audit Log Reference](https://tddocs.atlassian.net/wiki/spaces/PD/pages/208437326/Premium+Audit+Log+Reference)
+- [Premium Audit Log Events](https://docs.treasuredata.com/display/public/PD/Premium+Audit+Log+Events)
+- [Premium Audit Log Reference](https://docs.treasuredata.com/display/public/PD/Premium+Audit+Log+Reference)

--- a/tool-box/get-table-row-counts/README.md
+++ b/tool-box/get-table-row-counts/README.md
@@ -28,7 +28,7 @@ schedule:
 ```
 
 ### TD endpoint
-You need to modify td_endpoint setting in [get_row_count.dig](get_row_count.dig) file for your TD region accordingly. See our [document](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1085143/Sites+and+Endpoints#Endpoints) for details.
+You need to modify td_endpoint setting in [get_row_count.dig](get_row_count.dig) file for your TD region accordingly. See our [document](https://docs.treasuredata.com/display/public/PD/Sites+and+Endpoints#Endpoints) for details.
 ```
     td_endpoint: "https://api.treasuredata.com/"
 ```

--- a/tool-box/get_cdp_segments/README.md
+++ b/tool-box/get_cdp_segments/README.md
@@ -19,7 +19,7 @@ $ td table:create master_segment_lists segment_lists
 
 ### TD endpoint
 You need to modify td_endpoint / cdp_endpoint setting in dig file for your TD region accordingly.
-See our [document](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1085143/Sites+and+Endpoints#Endpoints) for details.
+See our [document](https://docs.treasuredata.com/display/public/PD/Sites+and+Endpoints#Endpoints) for details.
 ```
     td_endpoint: "https://api.treasuredata.co.jp/"
     cdp_endpoint: "https://api-cdp.treasuredata.co.jp/"

--- a/tool-box/s3_presigned/s3.dig
+++ b/tool-box/s3_presigned/s3.dig
@@ -16,7 +16,7 @@ _export:
     image: "digdag/digdag-python:3.7"
   _env:
     # For secrets documentation,
-    # See https://tddocs.atlassian.net/wiki/spaces/PD/pages/223379597/Setting+Workflow+Secrets+from+the+Command+Line
+    # See https://docs.treasuredata.com/display/public/PD/Setting+Workflow+Secrets+from+the+Command+Line
     S3_ACCESS_KEY_ID: ${secret:s3.access_key_id}
     S3_SECRET_ACCESS_KEY: ${secret:s3.secret_access_key}
 

--- a/tool-box/table-creates-and-drops-log/README.md
+++ b/tool-box/table-creates-and-drops-log/README.md
@@ -47,7 +47,7 @@ variables: 'google_sheet_id' and 'google_sheet_connection_name' as well as the s
     * Copy and paste the anomalous_table_creates_and_deletes_log.dig into the workflow.
 2. Specify the options available:
     * **database:** Set the name of an existing database where you would like your log files to be maintained. If there is not
-already a database you would like to use, please [create one](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083644/Database+and+Table+Management)
+already a database you would like to use, please [create one](https://docs.treasuredata.com/display/public/PD/Database+and+Table+Management)
 and enter the name here.
     * **lookback_range_days:** Should be an intiger representing a number of days, see Overview for more details.
     * **anomaly_range_days:** Should be an intiger representing a number of days, see Overview for more details.
@@ -58,7 +58,7 @@ delete actions. There is an
 , copy that ID and paste it into the google_sheet_id: in the workflow. If you do not want to use Google Sheets just enter
 '#' in front of this variable and in all lines within the '+create_google_sheet_of_anomalous_jobs' step of the workflow.
     * **google_sheet_connection_name:** Enter the name of your
-[Google Sheets connection](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081625/Google+Sheets+Export+Integration)
+[Google Sheets connection](https://docs.treasuredata.com/display/public/INT/Google+Sheets+Export+Integration)
 within your Treasure Data account.
     * **mailing_list:** Enter all emails you would like to recieve notifications of anomalous actions seperated by commas.
     * **exclude_databases:** If you do not wish to exclude databases please enter: []. Otherwise use regex to identify the


### PR DESCRIPTION
We plan to change the documentation URL from https://tddocs.atlassian.net/wiki/spaces/PD/overview to https://docs.treasuredata.com.

This repository has a variety of doc URLs of Treasure Data, so I revise them though the doc URL hasn't informed yet.