### PR TITLE
Convert Custom Script image to `digdag/digdag-python:3.9`

### DIFF
--- a/integration-box/auth0_batch/export.dig
+++ b/integration-box/auth0_batch/export.dig
@@ -22,7 +22,7 @@ _export:
 +monitor_and_get:
   py>: scripts.main.load
   docker:
-    image: "digdag/digdag-python:3.7"
+    image: "digdag/digdag-python:3.9"
   database: ${td.database}
   table: ${td.table}
   td_endpoint: ${td.endpoint}

--- a/integration-box/csv_import_via_http/http_csv_download_sample.dig
+++ b/integration-box/csv_import_via_http/http_csv_download_sample.dig
@@ -13,4 +13,4 @@ schedule:
     apikey: ${secret:td.apikey}
 
   docker:
-    image: "digdag/digdag-python:3.7"
+    image: "digdag/digdag-python:3.9"

--- a/integration-box/cuenote-import/JSON-API/cuenote_import_delivery_logs.dig
+++ b/integration-box/cuenote-import/JSON-API/cuenote_import_delivery_logs.dig
@@ -14,7 +14,7 @@ _export:
 
 +get_logs:
     docker:
-        image: "digdag/digdag-python:3.7"
+        image: "digdag/digdag-python:3.9"
     py>: get_logs.main
     _env:
         td_apikey: ${secret:td.apikey}

--- a/integration-box/cuenote-import/JSON-API/cuenote_import_master.dig
+++ b/integration-box/cuenote-import/JSON-API/cuenote_import_master.dig
@@ -5,7 +5,7 @@ schedule:
 
 +get_jobs:
     docker:
-        image: "digdag/digdag-python:3.7"
+        image: "digdag/digdag-python:3.9"
     py>: get_jobs.main
     _env:
         td_apikey: ${secret:td.apikey}

--- a/integration-box/cuenote-import/XML-API/cuenote_import_delivery_logs.dig
+++ b/integration-box/cuenote-import/XML-API/cuenote_import_delivery_logs.dig
@@ -14,7 +14,7 @@ _export:
 
 +get_logs:
     docker:
-        image: "digdag/digdag-python:3.7"
+        image: "digdag/digdag-python:3.9"
     py>: get_logs.main
     _env:
         td_apikey: ${secret:td.apikey}

--- a/integration-box/cuenote-import/XML-API/cuenote_import_master.dig
+++ b/integration-box/cuenote-import/XML-API/cuenote_import_master.dig
@@ -5,7 +5,7 @@ schedule:
 
 +get_jobs:
     docker:
-        image: "digdag/digdag-python:3.7"
+        image: "digdag/digdag-python:3.9"
     py>: get_jobs.main
     _env:
         td_apikey: ${secret:td.apikey}

--- a/integration-box/datarobot/datarobot_integration.dig
+++ b/integration-box/datarobot/datarobot_integration.dig
@@ -1,6 +1,6 @@
 +create_table_on_td:
   docker:
-    image: "digdag/digdag-python:3.7.3-stretch"
+    image: "digdag/digdag-python:3.9.3-stretch"
   _env:
       DR_USERNAME: ${secret:dr.username}
       DR_PRED_HOST: ${secret:dr.prediction_host}

--- a/integration-box/kintone/main.dig
+++ b/integration-box/kintone/main.dig
@@ -1,7 +1,7 @@
 timezone: Asia/Tokyo
 _export:
   docker:
-    image: "digdag/digdag-python:3.7"
+    image: "digdag/digdag-python:3.9"
   !include : 'config/kintone.yml'
   org: hogehoge
 

--- a/integration-box/onetrust/onetrust_inetegration.dig
+++ b/integration-box/onetrust/onetrust_inetegration.dig
@@ -16,7 +16,7 @@ _export:
 
     +call_data_profile_endpoint:
         docker:
-            image: "digdag/digdag-python:3.7"
+            image: "digdag/digdag-python:3.9"
         py>: onetrustintegration.getOneTrustProfileData
         _env:
             DATABASE: ${td.database}
@@ -28,7 +28,7 @@ _export:
 
     +call_collection_endpoint:
         docker:
-            image: "digdag/digdag-python:3.7"
+            image: "digdag/digdag-python:3.9"
         py>: onetrustintegration.getOneTrustCollectionData
         _env:
             DATABASE: ${td.database}

--- a/integration-box/pandas/pandas-df.dig
+++ b/integration-box/pandas/pandas-df.dig
@@ -8,7 +8,7 @@ _export:
     database_name: sample_datasets
     table_name: nasdaq
     docker:
-        image: "digdag/digdag-python:3.7"
+        image: "digdag/digdag-python:3.9"
     _env:
         TD_API_KEY: ${secret:td.apikey}
         TD_API_SERVER: ${secret:td.apiserver}
@@ -18,7 +18,7 @@ _export:
     database_name: ${td.database}
     table_name: my_df
     docker:
-        image: "digdag/digdag-python:3.7"
+        image: "digdag/digdag-python:3.9"
     _env:
         TD_API_KEY: ${secret:td.apikey}
         TD_API_SERVER: ${secret:td.apiserver}

--- a/integration-box/pelion-device-management/pelion_device.dig
+++ b/integration-box/pelion-device-management/pelion_device.dig
@@ -20,4 +20,4 @@ _export:
     TD_API_KEY: ${secret:td.apikey}
     TD_API_SERVER: ${secret:td.apiserver}
   docker:
-      image: "digdag/digdag-python:3.7"
+      image: "digdag/digdag-python:3.9"

--- a/integration-box/pyspark/pyspark.dig
+++ b/integration-box/pyspark/pyspark.dig
@@ -3,7 +3,7 @@
   database_name: ${td.database}
   table_name: www_access_processed
   docker:
-    image: 'digdag/digdag-python:3.7'
+    image: 'digdag/digdag-python:3.9'
   _env:
     TD_API_KEY: ${secret:td.apikey}
     TD_API_SERVER: ${secret:td.apiserver}
@@ -13,7 +13,7 @@
   database_name: ${td.database}
   table_name: www_access_processed
   docker:
-    image: 'digdag/digdag-python:3.7'
+    image: 'digdag/digdag-python:3.9'
   _env:
     TD_API_KEY: ${secret:td.apikey}
     TD_API_SERVER: ${secret:td.apiserver}
@@ -23,7 +23,7 @@
   database_name: ${td.database}
   table_name: pandas_table
   docker:
-    image: 'digdag/digdag-python:3.7'
+    image: 'digdag/digdag-python:3.9'
   _env:
     TD_API_KEY: ${secret:td.apikey}
     TD_API_SERVER: ${secret:td.apiserver}

--- a/integration-box/python/simple.dig
+++ b/integration-box/python/simple.dig
@@ -2,7 +2,7 @@
     py>: py_scripts.examples.print_arg
     msg: "Hello World"
     docker:
-        image: "digdag/digdag-python:3.7"
+        image: "digdag/digdag-python:3.9"
 
 +simple_with_env:
     py>: py_scripts.examples.print_env
@@ -11,19 +11,19 @@
         # One can use secrets as well.
         # See https://docs.treasuredata.com/display/public/PD/About+Workflow+Secret+Management
     docker:
-        image: "digdag/digdag-python:3.7"
+        image: "digdag/digdag-python:3.9"
 
 +simple_with_import:
     py>: py_scripts.examples.import_another_file
     docker:
-        image: "digdag/digdag-python:3.7"
+        image: "digdag/digdag-python:3.9"
 
 +simple_with_workflow_env:
     +store_msg:
         py>: py_scripts.examples.store_workflow_env
         msg: "Hello World"
         docker:
-            image: "digdag/digdag-python:3.7"
+            image: "digdag/digdag-python:3.9"
 
     +restore_msg:
         echo>: ${my_msg}

--- a/integration-box/rss/rss_import.dig
+++ b/integration-box/rss/rss_import.dig
@@ -8,7 +8,7 @@ schedule:
 
 +step1:
   docker:
-    image: "digdag/digdag-python:3.7"
+    image: "digdag/digdag-python:3.9"
   py>: py_scripts.tasks.rss_import
   dest_db: ${td.database}
   dest_table: ${td.table}

--- a/integration-box/s3/s3.dig
+++ b/integration-box/s3/s3.dig
@@ -7,7 +7,7 @@ _export:
   bucket: ${bucket}
   region_name: ${region}
   docker:
-    image: "digdag/digdag-python:3.7"
+    image: "digdag/digdag-python:3.9"
   _env:
     # For secrets documentation,
     # See https://docs.treasuredata.com/display/public/PD/Setting+Workflow+Secrets+from+the+Command+Line
@@ -19,7 +19,7 @@ _export:
   bucket: ${bucket}
   region_name: ${region}
   docker:
-      image: "digdag/digdag-python:3.7"
+      image: "digdag/digdag-python:3.9"
   _env:
     S3_ACCESS_KEY_ID: ${secret:s3.access_key_id}
     S3_SECRET_ACCESS_KEY: ${secret:s3.secret_access_key}

--- a/integration-box/scorer-cloud/scorer.dig
+++ b/integration-box/scorer-cloud/scorer.dig
@@ -10,7 +10,7 @@ _export:
 
 +load_sense_video:
   docker:
-    image: 'digdag/digdag-python:3.7'
+    image: 'digdag/digdag-python:3.9'
   py>: scorer.load_sense_video
   database: ${database}
   table: ${table}

--- a/integration-box/twitter-search/twitter-archiver.dig
+++ b/integration-box/twitter-search/twitter-archiver.dig
@@ -3,7 +3,7 @@ schedule:
 
 +query-monitoring:
     docker:
-        image: "digdag/digdag-python:3.7"
+        image: "digdag/digdag-python:3.9"
     py>: twitter-archiver.search_and_archive
     _env:
         td_apikey: ${secret:td.apikey}

--- a/integration-box/yahoo-dmp/yahoodmp_integration.dig
+++ b/integration-box/yahoo-dmp/yahoodmp_integration.dig
@@ -4,7 +4,7 @@ _export:
 
 +get_presigned_url:
   docker:
-    image: "digdag/digdag-python:3.7"
+    image: "digdag/digdag-python:3.9"
 
   py>: scripts.get_presigned_url.generate
   yahoo_api_url       : https://api.tgm.yahoo-net.jp/v3/userlists
@@ -21,7 +21,7 @@ _export:
 
 +yahoo_dmp_upload:
   docker:
-    image: "digdag/digdag-python:3.7"
+    image: "digdag/digdag-python:3.9"
 
   py>: scripts.put_userlist.upload
   sqlfile      : queries/userlist.sql

--- a/machine-learning-box/customer-lifetime-value/predict.dig
+++ b/machine-learning-box/customer-lifetime-value/predict.dig
@@ -11,7 +11,7 @@ _export:
     TD_API_KEY: ${secret:td.apikey}
     TD_API_SERVER: ${secret:td.apiserver}
   docker:
-      image: "digdag/digdag-python:3.7"
+      image: "digdag/digdag-python:3.9"
 
 +prepare:
   td>: queries/preprocess.sql

--- a/machine-learning-box/house-price-prediction/ingest.dig
+++ b/machine-learning-box/house-price-prediction/ingest.dig
@@ -6,7 +6,7 @@ _export:
   database: ${td.database}
   table: ${source}
   docker:
-    image: "digdag/digdag-python:3.7"
+    image: "digdag/digdag-python:3.9"
   _env:
     TD_API_KEY: ${secret:td.apikey}
     TD_API_SERVER: ${secret:td.apiserver}

--- a/machine-learning-box/house-price-prediction/regression-py.dig
+++ b/machine-learning-box/house-price-prediction/regression-py.dig
@@ -28,7 +28,7 @@ _export:
     dbname: ${td.database}
     source_table: ${source}
     docker:
-      image: 'digdag/digdag-python:3.7'
+      image: 'digdag/digdag-python:3.9'
     _env:
       TD_API_KEY: ${secret:td.apikey}
       TD_API_SERVER: ${secret:td.apiserver}

--- a/machine-learning-box/multi-touch-attribution/docs/more.md
+++ b/machine-learning-box/multi-touch-attribution/docs/more.md
@@ -60,7 +60,7 @@ The final task of the sample workflow below instantiates a temporal Python execu
 ```yaml
 +execute_python_code:
   docker:
-    image: "digdag/digdag-python:3.7"
+    image: "digdag/digdag-python:3.9"
   py>: py_scripts.main.run
   # ...
 ```

--- a/machine-learning-box/multi-touch-attribution/mta_shapley.dig
+++ b/machine-learning-box/multi-touch-attribution/mta_shapley.dig
@@ -11,7 +11,7 @@ _export:
   database: ${td.database}
   table: ${in_table}
   docker:
-    image: 'digdag/digdag-python:3.7'
+    image: 'digdag/digdag-python:3.9'
   _env:
     TD_API_KEY: ${secret:td.apikey}
     TD_API_SERVER: ${secret:td.apiserver}
@@ -31,7 +31,7 @@ _export:
 
 +execute_python_code:
   docker:
-    image: "digdag/digdag-python:3.7"
+    image: "digdag/digdag-python:3.9"
   py>: py_scripts.main.run
   db: ${in_db}
   table: ${in_table}_shuffled

--- a/machine-learning-box/recommendation/ingest.dig
+++ b/machine-learning-box/recommendation/ingest.dig
@@ -6,7 +6,7 @@ _export:
   database: ${td.database}
   table: ${td.table}
   docker:
-    image: "digdag/digdag-python:3.7"
+    image: "digdag/digdag-python:3.9"
   _env:
     TD_API_KEY: ${secret:td.apikey}
     TD_API_SERVER: ${secret:td.apiserver}

--- a/machine-learning-box/recommendation/recommend_spark.dig
+++ b/machine-learning-box/recommendation/recommend_spark.dig
@@ -8,7 +8,7 @@ _export:
   target_table: "recommendation_als"
   item_size: ${k}
   docker:
-    image: "digdag/digdag-python:3.7"
+    image: "digdag/digdag-python:3.9"
   _env:
     TD_API_KEY: ${secret:td.apikey}
     TD_API_SERVER: ${secret:td.apiserver}

--- a/machine-learning-box/sales-prediction/ingest.dig
+++ b/machine-learning-box/sales-prediction/ingest.dig
@@ -6,7 +6,7 @@ _export:
   database: ${td.database}
   table: ${source_table}
   docker:
-    image: "digdag/digdag-python:3.7"
+    image: "digdag/digdag-python:3.9"
   _env:
     TD_API_KEY: ${secret:td.apikey}
     TD_API_SERVER: ${secret:td.apiserver}

--- a/machine-learning-box/sales-prediction/predict_sales.dig
+++ b/machine-learning-box/sales-prediction/predict_sales.dig
@@ -10,7 +10,7 @@ _export:
   end_date: ${end_date}
   period: 365
   docker:
-    image: 'digdag/digdag-python:3.7'
+    image: 'digdag/digdag-python:3.9'
   _env:
     TD_API_KEY: ${secret:td.apikey}
     TD_API_SERVER: ${secret:td.apiserver}

--- a/machine-learning-box/sales-prediction/predict_sales_simple.dig
+++ b/machine-learning-box/sales-prediction/predict_sales_simple.dig
@@ -11,7 +11,7 @@ _export:
   period: 365
   with_aws: false
   docker:
-    image: 'digdag/digdag-python:3.7'
+    image: 'digdag/digdag-python:3.9'
   _env:
     TD_API_KEY: ${secret:td.apikey}
     TD_API_SERVER: ${secret:td.apiserver}

--- a/machine-learning-box/sentiment-analysis/ingest.dig
+++ b/machine-learning-box/sentiment-analysis/ingest.dig
@@ -7,7 +7,7 @@ _export:
   train_table: ${train_table}
   test_table: ${test_table}
   docker:
-    image: "digdag/digdag-python:3.7"
+    image: "digdag/digdag-python:3.9"
   _env:
     TD_API_KEY: ${secret:td.apikey}
     TD_API_SERVER: ${secret:td.apiserver}

--- a/machine-learning-box/sentiment-analysis/sentiment-analysis-chainer.dig
+++ b/machine-learning-box/sentiment-analysis/sentiment-analysis-chainer.dig
@@ -11,7 +11,7 @@ _export:
   input_table: "${test_table}_shuffled"
   output_table: "test_predicted_polarities_chainer"
   docker:
-    image: 'digdag/digdag-python:3.7'
+    image: 'digdag/digdag-python:3.9'
   _env:
     TD_API_KEY: ${secret:td.apikey}
     TD_API_SERVER: ${secret:td.apiserver}

--- a/machine-learning-box/sentiment-analysis/sentiment-analysis-simple.dig
+++ b/machine-learning-box/sentiment-analysis/sentiment-analysis-simple.dig
@@ -12,7 +12,7 @@ _export:
   train_table: ${train_table}
   test_table: ${test_table}
   docker:
-    image: 'digdag/digdag-python:3.7'
+    image: 'digdag/digdag-python:3.9'
   _env:
     TD_API_KEY: ${secret:td.apikey}
     TD_API_SERVER: ${secret:td.apiserver}

--- a/machine-learning-box/sentiment-analysis/sentiment-analysis.dig
+++ b/machine-learning-box/sentiment-analysis/sentiment-analysis.dig
@@ -11,7 +11,7 @@ _export:
   train_table: ${train_table}
   test_table: ${test_table}
   docker:
-    image: 'digdag/digdag-python:3.7'
+    image: 'digdag/digdag-python:3.9'
   _env:
     TD_API_KEY: ${secret:td.apikey}
     TD_API_SERVER: ${secret:td.apiserver}
@@ -25,7 +25,7 @@ _export:
 #  database: ${td.database}
 #  input_table: ${test_table}_shuffled
 #  docker:
-#    image: 'digdag/digdag-python:3.7'
+#    image: 'digdag/digdag-python:3.9'
 #  _env:
 #    TD_API_KEY: ${secret:td.apikey}
 #    TD_API_SERVER: ${secret:td.apiserver}

--- a/scenarios/kill_wf_attempt/kill_wf_attempt.dig
+++ b/scenarios/kill_wf_attempt/kill_wf_attempt.dig
@@ -7,7 +7,7 @@ _export:
 +run_long_task:
   py>: py_script.loop.loop
   docker:
-    image: "digdag/digdag-python:3.7"
+    image: "digdag/digdag-python:3.9"
 
 # This sla is a sample. You should change sla as you want.
 # If you want to specify a time, you should use "time" instead of duration.

--- a/tool-box/audit-log-detection-samples/audiglog_example.dig
+++ b/tool-box/audit-log-detection-samples/audiglog_example.dig
@@ -27,7 +27,7 @@ _export:
         TD_API_KEY: ${secret:td.apikey}
         TD_ENDPOINT: ${td.endpoint}
       docker:
-        image: "digdag/digdag-python:3.7"
+        image: "digdag/digdag-python:3.9"
     
     +result:
         td>: queries/nonactive_users_with_py.sql

--- a/tool-box/get-table-row-counts/get_row_count.dig
+++ b/tool-box/get-table-row-counts/get_row_count.dig
@@ -5,7 +5,7 @@ schedule:
 
 +step1:
   docker:
-    image: "digdag/digdag-python:3.7"
+    image: "digdag/digdag-python:3.9"
   py>: get_row_count.get_row_count
   dest_db: td_stats
   dest_table: row_count

--- a/tool-box/get_cdp_segments/cdp_segments.dig
+++ b/tool-box/get_cdp_segments/cdp_segments.dig
@@ -14,7 +14,7 @@ _export:
     
 +import_ms_lists_to_td:
   docker:
-    image: "digdag/digdag-python:3.7"
+    image: "digdag/digdag-python:3.9"
     
   py>: getcdpsegments.getSegmentLists
   _env:
@@ -32,7 +32,7 @@ _export:
   _do:
     +step1:
       docker:
-        image: "digdag/digdag-python:3.7"
+        image: "digdag/digdag-python:3.9"
     
       py>: getcdpsegments.getSegmentLists
       _env:

--- a/tool-box/job-monitoring/job-monitoring.dig
+++ b/tool-box/job-monitoring/job-monitoring.dig
@@ -3,7 +3,7 @@ schedule:
 
 +job-monitoring:
     docker:
-        image: "digdag/digdag-python:3.7"
+        image: "digdag/digdag-python:3.9"
     py>: job-monitoring.monitoring
     database: ${secret:td.database}
     table: ${secret:td.table}

--- a/tool-box/job-monitoring/job-monitoring/job-monitoring.dig
+++ b/tool-box/job-monitoring/job-monitoring/job-monitoring.dig
@@ -6,7 +6,7 @@ schedule:
 
 +job-monitoring:
     docker:
-        image: "digdag/digdag-python:3.7"
+        image: "digdag/digdag-python:3.9"
     py>: job-monitoring.monitoring
     database: ${td.database}
     table: ${td.table}

--- a/tool-box/s3_presigned/s3.dig
+++ b/tool-box/s3_presigned/s3.dig
@@ -13,7 +13,7 @@ _export:
   s3_filepath: ${s3_path}
   expires_in: ${expires_in}
   docker:
-    image: "digdag/digdag-python:3.7"
+    image: "digdag/digdag-python:3.9"
   _env:
     # For secrets documentation,
     # See https://docs.treasuredata.com/display/public/PD/Setting+Workflow+Secrets+from+the+Command+Line


### PR DESCRIPTION
Treasure Data plans to drop `-stretch`suffix images and `digdag/digdag-python:3.7` and start supporting `digdag/digdag-python:3.9`.

This PR aims to follow up this change.
https://docs.treasuredata.com/display/PD/Migration+Guide+for+Rootless+Docker+Images