### PR TITLE
BE-3128 Use newer endpoint for Kinesis integration

### DIFF
--- a/integration-box/Kinesis/README.md
+++ b/integration-box/Kinesis/README.md
@@ -6,7 +6,7 @@ This example processes data from a sample similar to Kinesis Firehose data strea
 
 1. Lambda handler function is the main method that processes steam events. When that function is invoked, Lambda invokes the handler method. By default, it has the name `lambda_function.lambda_handler`
 2. An event object, which is taken as an argument for lambda_handler is a JSON-formatted document.
-3. Kinesis Firehose event are base64 encoded and needs to be decoded. We also assume payload comes in JSON form.
+3. Kinesis Firehose events are base64 encoded and need to be decoded. We also assume the payload comes in JSON form.
 4. Below is the sample from firehose stream event in JSON form. And the lambda_function script is set to handle this input type.
 
 ```json

--- a/integration-box/Kinesis/README.md
+++ b/integration-box/Kinesis/README.md
@@ -27,7 +27,7 @@ This example processes data from a sample similar to Kinesis Firehose data strea
 
 ## Run
 
-- Copy and Paste script in `lambda_function.py` into your handler function.
+- Copy and paste script in `lambda_function.py` into your handler function.
 - Specify target database name, target table name and TD API Key using the `TD_DATABASE`, `TD_TABLE`, `TD_API_KEY` 
 environment variables.
 - Specify the correct endpoint for the region you are using using the `TD_ENDPOINT` environment variable:

--- a/integration-box/Kinesis/README.md
+++ b/integration-box/Kinesis/README.md
@@ -1,14 +1,15 @@
 # Amazon Kinesis Import Integration 
 
-This example processes data from a sample similar to Kinesis firehose data stream and imports into Treasure Data platform
+This example processes data from a sample similar to Kinesis Firehose data stream and imports into Treasure Data platform.
 
-# Things to know:
+## Things to know:
+
 1. Lambda handler function is the main method that processes steam events. When that function is invoked, Lambda invokes the handler method. By default, it has the name `lambda_function.lambda_handler`
 2. An event object, which is taken as an argument for lambda_handler is a JSON-formatted document.
-3. Kinesis data is base64 encoded and needs to be decoded. We also assume payload comes as JSON form
+3. Kinesis Firehose event are base64 encoded and needs to be decoded. We also assume payload comes in JSON form.
 4. Below is the sample from firehose stream event in JSON form. And the lambda_function script is set to handle this input type.
 
-```
+```json
 {
   "invocationId": "invocationIdExample",
   "deliveryStreamArn": "arn:aws:kinesis:EXAMPLE",
@@ -22,8 +23,15 @@ This example processes data from a sample similar to Kinesis firehose data strea
   ]
 }
 ```
-4. If your streaming input event is of different form, the lambda_handler function has to be changed accordingly to parse the data. 
+4. If your streaming input event is of different form, the `lambda_handler` function has to be changed accordingly to parse the data. 
 
-# Run
-- Copy and Paste script in lambda_function.py into your handler function
-- Specify target database name, target table name and TD API Key, at td_database, td_table, td_write_key
+## Run
+
+- Copy and Paste script in `lambda_function.py` into your handler function.
+- Specify target database name, target table name and TD API Key using the `TD_DATABASE`, `TD_TABLE`, `TD_API_KEY` 
+environment variables.
+- Specify the correct endpoint for the region you are using using the `TD_ENDPOINT` environment variable:
+  * Europe: https://eu01.records.in.treasuredata.com
+  * US: https://us01.records.in.treasuredata.com
+  * Korea: https://ap02.records.in.treasuredata.com
+  * Japan: https://ap01.records.in.treasuredata.com


### PR DESCRIPTION
Use newer, more robust endpoint for Kinesis integration.

This uses environment variables for easier configuration (which might require a [documentation](https://docs.treasuredata.com/display/public/INT/Amazon+Kinesis+Import+Integration) change), and expect Python at least 3.9.