### PR TITLE
Use gz compression

### DIFF
--- a/td/s3-v2/td_s3_v2.dig
+++ b/td/s3-v2/td_s3_v2.dig
@@ -3,7 +3,7 @@ timezone: UTC
 _export:
   td:
     database: sample_datasets
- 
+
 +s3v2_export:
   td>: queries/sample.sql
   database: ${td.database}
@@ -13,7 +13,7 @@ _export:
     path: /path/to/results_${moment(session_time).format("YYYYMMDD")}.csv
     sse_type: sse-s3
     format: csv
-    compression: none
+    compression: gz
     header: true
     delimiter: default
     null_value:  empty


### PR DESCRIPTION
Change `compression` option value because current validation allows no compression (default behavior) or gzip. So, `gz` is better than default behavior as a setting sample.