### PR TITLE
Fixing backup buffering capacity exceeded error

### DIFF
--- a/tool-box/ps_backup_restore/config/input_params.yml
+++ b/tool-box/ps_backup_restore/config/input_params.yml
@@ -1,2 +1,2 @@
-enable_backup: no
-enable_restore: yes
+enable_backup: yes
+enable_restore: no

--- a/tool-box/ps_backup_restore/master_seg_backup.dig
+++ b/tool-box/ps_backup_restore/master_seg_backup.dig
@@ -15,105 +15,63 @@ _export:
         empty_tables: ["${backup.stg_folder_curr_config_tbl}","${backup.stg_seg_curr_config_tbl}"]
         database: ${td.database}
 
+#BACKUP MASTER SEGMENT
 +get_master_seg_config:
-    +ms_api_call:
-        http>: https://api-cdp.treasuredata.com/audiences/${backup.src_ms_id}
-        method: GET
-        headers:
-            - Authorization: "TD1 ${secret:td.apikey}"
-        store_content: true
+    +call_backup_script:
+      docker:
+          image: "digdag/digdag-python:3.9"
+      py>: python_script.backup_main.main
+      url: https://api-cdp.treasuredata.com/audiences/${backup.src_ms_id}
+      s3_object_key: ${moment(session_time).format("YYYYMMDD")}/ms_config_${moment(session_time).format("HHmmss")}.json
+      bk_type: master_segment
+      db_name: ${td.database}
+      table: ${backup.stg_ms_config_tbl} 
+      _env:
+          TD_API_KEY: ${secret:td.apikey}
+          TD_API_SERVER: ${secret:endpoint}
+          AWS_BUCKET: ${backup.s3.bucket}
+          AWS_ACCESS_KEY_ID: ${secret:s3.access_key_id}
+          AWS_SECRET_ACCESS_KEY: ${secret:s3.secret_access_key}
+          TD_HOME: /home/td-user
 
-    +write_result_to_s3:
-        +query_for_json:
-            td>:
-            query: SELECT '${JSON.parse(http.last_content)}'
-            
-        +load:
-            td_result_export>:
-            job_id: ${td.last_job.id}
-            result_connection: ${backup.s3.connection_name}
-            result_settings:
-                bucket: ${backup.s3.bucket}
-                format: jsonl
-                path: ${moment(session_time).format("YYYYMMDD")}/ms_config_${moment(session_time).format("HHmmss")}.json
-
-    +write_result_to_td:
-        +insert:
-            td>:
-                data: "INSERT INTO ${td.database}.${backup.stg_ms_config_tbl} SELECT JSON_FORMAT(JSON '${JSON.parse(http.last_content)}') as config"
-
-    
-
-    #echo>: ${http.last_content}
-
+#BACKUP FOLDER CONFIG
 +get_folder_config:
-    +folder_api_call:
-        http>: https://api-cdp.treasuredata.com/entities/by-folder/${backup.root_folder_id}?depth=10
-        method: GET
-        headers:
-            - Authorization: "TD1 ${secret:td.apikey}"
-        store_content: true
-
-    +write_result_to_s3:
-        +query_for_json:
-            td>:
-            query: SELECT '${JSON.parse(http.last_content)}'
-
-        +load:
-            td_result_export>:
-            job_id: ${td.last_job.id}
-            result_connection: ${backup.s3.connection_name}
-            result_settings:
-                bucket: ${backup.s3.bucket}
-                format: jsonl
-                path: ${moment(session_time).format("YYYYMMDD")}/folder_config_${moment(session_time).format("HHmmss")}.json
-
-    +write_folder_result_to_td:
-        +insert:
-            td>:
-                data: "INSERT INTO ${td.database}.${backup.stg_folder_curr_config_tbl} SELECT JSON_FORMAT(JSON '${JSON.parse(http.last_content)}') as config"
-
-        +extract_config:
-            td>: queries/folder_config_extract.sql
-            insert_into: ${td.database}.${backup.stg_folder_extract_tbl} 
-            database: ${td.database}
-
-    #For each folder obtain list of segments and loop through to get configuration of each segment
+    +call_backup_script:
+      docker:
+          image: "digdag/digdag-python:3.9"
+      py>: python_script.backup_main.main
+      url: https://api-cdp.treasuredata.com/entities/by-folder/${backup.root_folder_id}?depth=10
+      s3_object_key: ${moment(session_time).format("YYYYMMDD")}/folder_config_${moment(session_time).format("HHmmss")}.json
+      bk_type: folder_config
+      db_name: ${td.database}
+      table: ${backup.stg_folder_curr_config_tbl} 
+      _env:
+          TD_API_KEY: ${secret:td.apikey}
+          TD_API_SERVER: ${secret:endpoint}
+          AWS_BUCKET: ${backup.s3.bucket}
+          AWS_ACCESS_KEY_ID: ${secret:s3.access_key_id}
+          AWS_SECRET_ACCESS_KEY: ${secret:s3.secret_access_key}
+          TD_HOME: /home/td-user
+    +extract_config:
+      td>: queries/folder_config_extract.sql
+      insert_into: ${td.database}.${backup.stg_folder_extract_tbl} 
+      database: ${td.database}
+    
+#BACKUP ALL SEGMENTS
 +get_segment_config:
-    +loop_each_segment:
-        td_for_each>: queries/segment_list.sql
-        _do:
-            +run_segment_api:
-                http>: https://api-cdp.treasuredata.com/entities/segments/${td.each.current_node_id}
-                method: GET
-                headers:
-                    - Authorization: "TD1 ${secret:td.apikey}"
-                store_content: true
-            +write_curr_config:
-                td>:
-                    data: "INSERT INTO ${td.database}.${backup.stg_seg_curr_config_tbl} SELECT JSON_FORMAT(JSON '${JSON.parse(http.last_content)}') as config"
-
-            +write_to_td:
-                +insert:
-                    td>:
-                    query: "INSERT INTO ${td.database}.${backup.stg_seg_config_tbl} SELECT JSON_FORMAT(JSON '${JSON.parse(http.last_content)}') as config"
-    +write_to_s3:
-        +query_for_json:
-            td>: queries/segments_config_extract.sql
-            database: ${td.database}
-        
-        +export_to_s3:
-            td_result_export>:
-            job_id: ${td.last_job.id}
-            result_connection: ${backup.s3.connection_name}
-            result_settings:
-                bucket: ${backup.s3.bucket}
-                format: jsonl
-                path: ${moment(session_time).format("YYYYMMDD")}/all_segments_config_${moment(session_time).format("HHmmss")}.json
-
-#    +segment_api_call:
-#        http>: https://api-cdp.treasuredata.com/entities/segments/${segment_id}
-#+store_result_to_s3:der obtain list of segments and loop through to get configuration of each segment
-#    +get_segment_config:
-#
-#+store_result_to_s3:
+    +call_backup_script:
+      docker:
+          image: "digdag/digdag-python:3.9"
+      py>: python_script.backup_main.main_all_segments
+      url: https://api-cdp.treasuredata.com/entities/segments
+      s3_object_key: ${moment(session_time).format("YYYYMMDD")}/all_segments_config_${moment(session_time).format("HHmmss")}.json
+      db_name: ${td.database}
+      read_table: ${backup.stg_folder_extract_tbl} 
+      write_table: ${backup.stg_seg_config_tbl}
+      _env:
+          TD_API_KEY: ${secret:td.apikey}
+          TD_API_SERVER: ${secret:endpoint}
+          AWS_BUCKET: ${backup.s3.bucket}
+          AWS_ACCESS_KEY_ID: ${secret:s3.access_key_id}
+          AWS_SECRET_ACCESS_KEY: ${secret:s3.secret_access_key}
+          TD_HOME: /home/td-user

--- a/tool-box/ps_backup_restore/python_script/S3.py
+++ b/tool-box/ps_backup_restore/python_script/S3.py
@@ -1,0 +1,20 @@
+import boto3
+import json
+import os
+from boto3.s3.transfer import TransferConfig
+
+
+BUCKET = os.environ['AWS_BUCKET']
+AWS_ACCESS_KEY_ID = os.environ['AWS_ACCESS_KEY_ID']
+AWS_SECRET_ACCESS_KEY = os.environ['AWS_SECRET_ACCESS_KEY']
+
+def uploadFiletoS3(s3_object_key,local_file_path):
+    s3 = boto3.client('s3', aws_access_key_id=AWS_ACCESS_KEY_ID, aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
+    config = boto3.s3.transfer.TransferConfig(multipart_chunksize=1024 * 1) #1MB
+
+    try:
+        s3.upload_file(local_file_path, BUCKET, s3_object_key, Config=config)
+        print(f"Wrote {s3_object_key} to S3 successfully!")
+    except Exception as e:
+        raise Exception(f"Error writing the backup data to S3: {str(e)}")
+

--- a/tool-box/ps_backup_restore/python_script/backup_main.py
+++ b/tool-box/ps_backup_restore/python_script/backup_main.py
@@ -1,0 +1,162 @@
+import os
+import requests
+import json
+import pandas as pd
+import pytd
+import re
+import python_script.S3 as s3
+
+td_api_key = os.environ['TD_API_KEY']
+td_endpoint_base = os.environ['TD_API_SERVER']
+td_home = os.environ['TD_HOME']
+
+def uploadDataToTD(data, td_write_db, td_write_table):
+    try:
+        client = pytd.Client(apikey=td_api_key,endpoint=td_endpoint_base,database=td_write_db, default_engine='presto')
+    except BaseException:
+        raise Exception('Error calling pytd.Client')
+
+    try:
+        client.load_table_from_dataframe(data, td_write_table, writer='bulk_import', if_exists='append')
+    except BaseException:
+        raise Exception('Error writing table back into TD Database')
+
+
+def getListSegmentsfromTD(td_read_db, td_read_table):
+    query = f'''select array_join(array_agg(current_node_id), ',') as segments  
+          from (
+            select current_node_id
+            from {td_read_db}.{td_read_table}
+            where current_node_type='segment-batch' 
+            group by 1
+          )'''
+    try:
+        client = pytd.Client(apikey=td_api_key,endpoint=td_endpoint_base,database=td_read_db, default_engine='presto')
+    except BaseException:
+        raise Exception('Error calling pytd.Client')
+
+    try:
+        dt = client.query(query)
+        df = pd.DataFrame(columns=dt['columns'], data=dt['data'])
+        print(df)
+        return df['segments'].values[0]
+    except BaseException as ex:
+        raise Exception('Error reading table from TD Database')
+        return ''
+
+
+def saveDatatoLocal(json_data):
+    try:
+      
+      folder = f'{td_home}/pmi_master_seg'
+      os.system(f"rm -rf {folder}")
+      os.system(f"mkdir {folder}")
+      
+      local_file_path = f'{folder}/temp_segment_json.json'
+
+      with open(local_file_path, 'w') as f:
+        json.dump(json_data, f)
+      return local_file_path
+    except Exception as e:
+      raise Exception(f"Error saving data to local: {str(e)}")
+      return None
+
+
+def exportSegmentData(url):
+        headers = {
+            "AUTHORIZATION": f"TD1 {td_api_key}"
+            }
+      
+        try:
+            response = requests.get(url, headers=headers)
+            data = response.text
+            print(data)
+            data = json.loads(data)
+            formatted_json = json.dumps(data)
+            formatted_json = f'{{"_col0":{formatted_json}}}'
+            result = json.loads(formatted_json)
+            response.raise_for_status()
+            if response.ok:
+                return result
+        except Exception as ex:
+            raise Exception(f'Export segment data failed {ex}')
+        return None 
+
+
+def exportSubSegmentData(url,segment_id):
+        headers = {
+            "AUTHORIZATION": f"TD1 {td_api_key}"
+            }
+      
+        try:
+            response = requests.get(f'{url}/{segment_id}', headers=headers)
+            data = response.text
+            data = json.loads(data)
+            response.raise_for_status()
+            if response.ok:
+                return data
+        except Exception as ex:
+            raise Exception(f'Export segment data failed {ex}')
+        return None 
+
+def writeFolderConfigtoTD(json_data, db_name, table):
+    pattern = r"([:\[,{]\s*)'(.*?)'(?=\s*[:,\]}])"
+    try:
+      df = pd.DataFrame(json_data["_col0"]["data"])
+      df = df.applymap(lambda x: re.sub(pattern, r'\1"\2"',str(x)))
+      print(df)
+      uploadDataToTD(df,db_name,table)
+    except Exception as ex:
+      raise Exception(f'Write Folder Config data to TD failed {ex}')
+
+
+def writeMasterSegmenttoTD(json_data, db_name, table):
+    pattern = r"([:\[,{]\s*)'(.*?)'(?=\s*[:,\]}])"
+    try:
+      df = pd.DataFrame()
+      df['config'] = [json_data["_col0"]]
+      df = df.applymap(lambda x: re.sub(pattern, r'\1"\2"',str(x)))
+      print(df)
+      uploadDataToTD(df,db_name,table)
+    except Exception as ex:
+      raise Exception(f'Write Master Segment data to TD failed {ex}')
+
+def writeAllSegmentstoTD(data, db_name, table):
+    pattern = r"([:\[,{]\s*)'(.*?)'(?=\s*[:,\]}])"
+    try:
+      df = pd.DataFrame(data)
+      df = df.applymap(lambda x: re.sub(pattern, r'\1"\2"',str(x)))
+      print(df)
+      uploadDataToTD(df,db_name,table)
+    except Exception as ex:
+      raise Exception(f'Write all Segments data to TD failed {ex}')
+
+
+def main(url,s3_object_key,bk_type,db_name, table):
+  print("********************************CALL TD API***********************************")
+  data = exportSegmentData(url)
+  local_file_path = saveDatatoLocal(data)
+  print("********************************WRITE RESULT TO S3***********************************")
+  s3.uploadFiletoS3(s3_object_key,local_file_path)
+  print("********************************WRITE RESULT TO TD***********************************")
+  if bk_type == 'folder_config':
+    writeFolderConfigtoTD(data, db_name, table)
+  elif bk_type == 'master_segment':
+    writeMasterSegmenttoTD(data,db_name,table)
+
+def main_all_segments(url,s3_object_key,db_name, read_table, write_table):
+  print("********************************CALL TD API***********************************")
+  segments = getListSegmentsfromTD(db_name, read_table)
+  list_segments = list(segments.split(","))
+  data = []
+  for sg in list_segments:
+    js = exportSubSegmentData(url,sg)
+    data.append(js)
+  data_json = json.dumps(data)
+  data_json = f'{{"data":{data_json}}}'
+  data_json = json.loads(data_json)
+  local_file_path = saveDatatoLocal(data_json)
+  print("********************************WRITE RESULT TO TD***********************************")
+  writeAllSegmentstoTD(data_json, db_name, write_table)
+  print("********************************WRITE RESULT TO S3***********************************")
+  s3.uploadFiletoS3(s3_object_key,local_file_path)

--- a/tool-box/ps_backup_restore/python_script/restore_main.py
+++ b/tool-box/ps_backup_restore/python_script/restore_main.py
@@ -59,7 +59,7 @@ client = client('s3',
 res_fol = client.get_object(Bucket=BUCKET,Key=FOLDER_FILE_TO_READ)
 folders = res_fol["Body"]
 folders = json.load(folders)
-folders = json.loads(folders['_col0'])
+folders = folders['_col0']
 
 folder_dict = {}
 segment_dict = {}

--- a/tool-box/ps_backup_restore/queries/folder_config_extract.sql
+++ b/tool-box/ps_backup_restore/queries/folder_config_extract.sql
@@ -1,10 +1,7 @@
-WITH records AS (
-  select CAST(json_extract(config, '$.data') as ARRAY<JSON>) records from ${td.database}.${backup.stg_folder_curr_config_tbl}
-)
-SELECT CAST(json_extract(record, '$.relationships.parentFolder.data.id') as int) parent_node_id,
-       CAST(json_extract(record, '$.relationships.parentFolder.data.type') as VARCHAR) parent_node_type,
-       CAST(json_extract(record, '$.id') AS INT) current_node_id,
-       CAST(json_extract(record, '$.type') AS VARCHAR) current_node_type,
-       CAST(json_extract(record, '$.attributes.name') AS VARCHAR) current_node_name,
-       CAST(json_extract(record, '$.attributes.description') AS VARCHAR) current_node_desc
-       FROM records CROSS JOIN UNNEST(records) AS t(record);
+SELECT CAST(json_extract(relationships, '$.parentFolder.data.id') as int) parent_node_id,
+       CAST(json_extract(relationships, '$.parentFolder.data.type') as VARCHAR) parent_node_type,
+       CAST(id AS INT) current_node_id,
+       CAST(type AS VARCHAR) current_node_type,
+       CAST(json_extract(attributes, '$.name') AS VARCHAR) current_node_name,
+       CAST(json_extract(attributes, '$.description') AS VARCHAR) current_node_desc
+FROM ${td.database}.${backup.stg_folder_curr_config_tbl};


### PR DESCRIPTION
This pull request aims to address the **"Buffering capacity exceeded"** error in the master_seg_backup.dig workflow.

**Root cause:** The error occurred due to the JSON file size exceeding the limit allowed by the Digdag HTTP>: operator.

**Solution:** The script has been modified to utilize Python for exporting the file. The following changes have been made:

1. New files added:
- tool-box/ps_backup_restore/python_script/S3.py: Used for uploading the JSON file to S3.
- tool-box/ps_backup_restore/python_script/backup_main.py: Used for exporting, writing to the TD database, and uploading the JSON file to S3.

2. Modified files:
- tool-box/ps_backup_restore/master_seg_backup.dig: Edited to incorporate the Python backup script.
- tool-box/ps_backup_restore/python_script/restore_main.py: A line of code has been modified to remove the json.loads() parsing function since the JSON file is already in JSON format within the backup script.
- tool-box/ps_backup_restore/queries/folder_config_extract.sql: This query has been edited to retrieve data from the TD table that is already in JSON format.