### PR TITLE
Refactoring: Relocating URL Endpoint Configuration from Hardcoded Values to YML File

### DIFF
--- a/tool-box/ps_backup_restore/README.md
+++ b/tool-box/ps_backup_restore/README.md
@@ -11,10 +11,11 @@ With this solution, users can:
     - Restore all Folders and all Segments as it is in the backup configuration in Audience Studio V5
 
 TD Secrets that are common to backup and restore:
-- endpoint - For US region it should be `https://api.treasuredata.com`, Europe → `api.eu01.treasuredata.com` and JP region → `api.treasuredata.co.jp` 
 - s3.access_key_id - AWS access key ID to connect to s3
 - s3.secret_access_key - Secret access key to connect to s3
-- td.apikey - Master/Write-only API Key of the user
+- td.backup_apikey - Master/Write-only API Key of the user for the backup server
+- td.restore_apikey - Master/Write-only API Key of the user for the restore server
+
 
 ## Backup Parent Segment Configuration:
 
@@ -54,13 +55,14 @@ The end user does not need to have any of SQL or digdag or Python expertise as u
 	- root_folder_id - Folder ID of the root at Audience Studio V5. As in below screenshot, open Audience Studio V5, go to respect parent segment and identify the root folder ID from the url. In this example screenshot, 390702 is the root folder ID for parent segment pse_restore_0419.
 	
 	![](images/root-folder-ex.png)
-
+  - td_backup_endpoint - The endpoint of the backup server, for US region it should be `https://api.treasuredata.com`, Europe → `https://api.eu01.treasuredata.com` and JP region → `https://api.treasuredata.co.jp`
+  - td_backup_cdp_endpoint: The cdp endpoint of the backup server, for US region it should be `https://api-cdp.treasuredata.com`, Europe → `https://api-cdp.eu01.treasuredata.com` and JP region → `https://api-cdp.treasuredata.co.jp`
 	- stg_ms_config_tbl - Table where the Parent Segment Configuration will be backed up in TD.
 	- stg_folder_curr_config_tbl - Temporary table that holds current Folder Configuration.
 	- stg_folder_extract_tbl - Table where the folder configurations are persisted from every run of the backup workflow.
 	- stg_seg_curr_config_tbl - Temporary table holds current Segment Configuration.
 	- stg_seg_config_tbl - Table where the segment configurations are persisted from every run of the backup workflow.
-	- s3.connection_name - Name of AWS S3 Authentication, configured at Integration Hub.
+  - stg_s3_json_files: The table that contains the S3 file paths of the Parent Segment, Folder configuration, and all Segments for each run of the backup workflow.
 	- s3.bucket - AWS bucket where all the three configurations will be persisted.
 
 4. Run main_wf.dig now to take a complete backup of all three configurations
@@ -95,6 +97,8 @@ Restoring Parent Segment from an existing backup has 3 parts to it.
 
     - config/restore_parent_seg.yml - It is the main configuration file that needs to be set for restore process and this will require the following **parameters**:
 		- ms_name - New name for the Parent Segment
+    - td_restore_endpoint: The endpoint of the restore server, for US region it should be `https://api.treasuredata.com`, Europe → `https://api.eu01.treasuredata.com` and JP region → `https://api.treasuredata.co.jp`
+    - td_restore_cdp_endpoint: The cdp endpoint of the restore server, for US region it should be `https://api-cdp.treasuredata.com`, Europe → `https://api-cdp.eu01.treasuredata.com` and JP region → `https://api-cdp.treasuredata.co.jp`
 		- ms_table_restore - Table Name to write results from Parent Segment configuration json file
 		- folder_stg_tbl - Table Name to write results from Folder configuration json file
 		- root_folder_id - Not required to be set for Part 1

--- a/tool-box/ps_backup_restore/README.md
+++ b/tool-box/ps_backup_restore/README.md
@@ -55,14 +55,14 @@ The end user does not need to have any of SQL or digdag or Python expertise as u
 	- root_folder_id - Folder ID of the root at Audience Studio V5. As in below screenshot, open Audience Studio V5, go to respect parent segment and identify the root folder ID from the url. In this example screenshot, 390702 is the root folder ID for parent segment pse_restore_0419.
 	
 	![](images/root-folder-ex.png)
-  - td_backup_endpoint - The endpoint of the backup server, for US region it should be `https://api.treasuredata.com`, Europe → `https://api.eu01.treasuredata.com` and JP region → `https://api.treasuredata.co.jp`
-  - td_backup_cdp_endpoint: The cdp endpoint of the backup server, for US region it should be `https://api-cdp.treasuredata.com`, Europe → `https://api-cdp.eu01.treasuredata.com` and JP region → `https://api-cdp.treasuredata.co.jp`
+    - td_backup_endpoint - The endpoint of the backup server, for US region it should be `https://api.treasuredata.com`, Europe → `https://api.eu01.treasuredata.com` and JP region → `https://api.treasuredata.co.jp`
+    - td_backup_cdp_endpoint: The cdp endpoint of the backup server, for US region it should be `https://api-cdp.treasuredata.com`, Europe → `https://api-cdp.eu01.treasuredata.com` and JP region → `https://api-cdp.treasuredata.co.jp`
 	- stg_ms_config_tbl - Table where the Parent Segment Configuration will be backed up in TD.
 	- stg_folder_curr_config_tbl - Temporary table that holds current Folder Configuration.
 	- stg_folder_extract_tbl - Table where the folder configurations are persisted from every run of the backup workflow.
 	- stg_seg_curr_config_tbl - Temporary table holds current Segment Configuration.
 	- stg_seg_config_tbl - Table where the segment configurations are persisted from every run of the backup workflow.
-  - stg_s3_json_files: The table that contains the S3 file paths of the Parent Segment, Folder configuration, and all Segments for each run of the backup workflow.
+    - stg_s3_json_files: The table that contains the S3 file paths of the Parent Segment, Folder configuration, and all Segments for each run of the backup workflow.
 	- s3.bucket - AWS bucket where all the three configurations will be persisted.
 
 4. Run main_wf.dig now to take a complete backup of all three configurations
@@ -97,8 +97,8 @@ Restoring Parent Segment from an existing backup has 3 parts to it.
 
     - config/restore_parent_seg.yml - It is the main configuration file that needs to be set for restore process and this will require the following **parameters**:
 		- ms_name - New name for the Parent Segment
-    - td_restore_endpoint: The endpoint of the restore server, for US region it should be `https://api.treasuredata.com`, Europe → `https://api.eu01.treasuredata.com` and JP region → `https://api.treasuredata.co.jp`
-    - td_restore_cdp_endpoint: The cdp endpoint of the restore server, for US region it should be `https://api-cdp.treasuredata.com`, Europe → `https://api-cdp.eu01.treasuredata.com` and JP region → `https://api-cdp.treasuredata.co.jp`
+        - td_restore_endpoint: The endpoint of the restore server, for US region it should be `https://api.treasuredata.com`, Europe → `https://api.eu01.treasuredata.com` and JP region → `https://api.treasuredata.co.jp`
+        - td_restore_cdp_endpoint: The cdp endpoint of the restore server, for US region it should be `https://api-cdp.treasuredata.com`, Europe → `https://api-cdp.eu01.treasuredata.com` and JP region → `https://api-cdp.treasuredata.co.jp`
 		- ms_table_restore - Table Name to write results from Parent Segment configuration json file
 		- folder_stg_tbl - Table Name to write results from Folder configuration json file
 		- root_folder_id - Not required to be set for Part 1

--- a/tool-box/ps_backup_restore/config/backup_parent_seg.yml
+++ b/tool-box/ps_backup_restore/config/backup_parent_seg.yml
@@ -1,3 +1,5 @@
+td_backup_endpoint: https://api.treasuredata.com
+td_backup_cdp_endpoint: https://api-cdp.treasuredata.com
 src_ms_id: 164596
 root_folder_id: 179205
 stg_ms_config_tbl: audience_164596_ms
@@ -6,5 +8,4 @@ stg_folder_extract_tbl: audience_164596_folder_ext
 stg_seg_curr_config_tbl: audience_164596_sc
 stg_seg_config_tbl: audience_164596_seg_extract
 s3:
-  connection_name: ganesh_ms_backup
   bucket: ganesh-demo-mar

--- a/tool-box/ps_backup_restore/config/backup_parent_seg.yml
+++ b/tool-box/ps_backup_restore/config/backup_parent_seg.yml
@@ -7,5 +7,6 @@ stg_folder_curr_config_tbl: audience_164596_fc
 stg_folder_extract_tbl: audience_164596_folder_ext
 stg_seg_curr_config_tbl: audience_164596_sc
 stg_seg_config_tbl: audience_164596_seg_extract
+stg_s3_json_files: s3_backup_json_files
 s3:
   bucket: ganesh-demo-mar

--- a/tool-box/ps_backup_restore/config/restore_parent_seg.yml
+++ b/tool-box/ps_backup_restore/config/restore_parent_seg.yml
@@ -1,5 +1,8 @@
 ms_name: pse_restore_0509
 
+td_restore_endpoint: https://api.treasuredata.com
+td_restore_cdp_endpoint: https://api-cdp.treasuredata.com
+
 ms_table_restore: pse_restore_ms
 folder_stg_tbl: pse_folder_stg_restore
 

--- a/tool-box/ps_backup_restore/master_seg_backup.dig
+++ b/tool-box/ps_backup_restore/master_seg_backup.dig
@@ -7,7 +7,7 @@ _export:
 +create_config_bckup_table:
     +create:
         td_ddl>: 
-        create_tables: ["${backup.stg_ms_config_tbl}","${backup.stg_folder_extract_tbl}","${backup.stg_seg_config_tbl}"]
+        create_tables: ["${backup.stg_ms_config_tbl}","${backup.stg_folder_extract_tbl}","${backup.stg_seg_config_tbl}", "${backup.stg_s3_json_files}"]
         database: ${td.database}
     
     +create_tmp_tables:
@@ -21,14 +21,16 @@ _export:
       docker:
           image: "digdag/digdag-python:3.9"
       py>: python_script.backup_main.main
-      url: https://api-cdp.treasuredata.com/audiences/${backup.src_ms_id}
+      url: audiences/${backup.src_ms_id}
       s3_object_key: ${moment(session_time).format("YYYYMMDD")}/ms_config_${moment(session_time).format("HHmmss")}.json
       bk_type: master_segment
       db_name: ${td.database}
       table: ${backup.stg_ms_config_tbl} 
+      s3_table: ${backup.stg_s3_json_files} 
       _env:
-          TD_API_KEY: ${secret:td.apikey}
-          TD_API_SERVER: ${secret:endpoint}
+          TD_API_KEY: ${secret:td.backup_apikey}
+          TD_API_SERVER: ${backup.td_backup_endpoint}
+          TD_API_CDP: ${backup.td_backup_cdp_endpoint}
           AWS_BUCKET: ${backup.s3.bucket}
           AWS_ACCESS_KEY_ID: ${secret:s3.access_key_id}
           AWS_SECRET_ACCESS_KEY: ${secret:s3.secret_access_key}
@@ -40,14 +42,16 @@ _export:
       docker:
           image: "digdag/digdag-python:3.9"
       py>: python_script.backup_main.main
-      url: https://api-cdp.treasuredata.com/entities/by-folder/${backup.root_folder_id}?depth=10
+      url: entities/by-folder/${backup.root_folder_id}?depth=10
       s3_object_key: ${moment(session_time).format("YYYYMMDD")}/folder_config_${moment(session_time).format("HHmmss")}.json
       bk_type: folder_config
       db_name: ${td.database}
       table: ${backup.stg_folder_curr_config_tbl} 
+      s3_table: ${backup.stg_s3_json_files} 
       _env:
-          TD_API_KEY: ${secret:td.apikey}
-          TD_API_SERVER: ${secret:endpoint}
+          TD_API_KEY: ${secret:td.backup_apikey}
+          TD_API_SERVER: ${backup.td_backup_endpoint}
+          TD_API_CDP: ${backup.td_backup_cdp_endpoint}
           AWS_BUCKET: ${backup.s3.bucket}
           AWS_ACCESS_KEY_ID: ${secret:s3.access_key_id}
           AWS_SECRET_ACCESS_KEY: ${secret:s3.secret_access_key}
@@ -63,14 +67,16 @@ _export:
       docker:
           image: "digdag/digdag-python:3.9"
       py>: python_script.backup_main.main_all_segments
-      url: https://api-cdp.treasuredata.com/entities/segments
+      url: entities/segments
       s3_object_key: ${moment(session_time).format("YYYYMMDD")}/all_segments_config_${moment(session_time).format("HHmmss")}.json
       db_name: ${td.database}
       read_table: ${backup.stg_folder_extract_tbl} 
       write_table: ${backup.stg_seg_config_tbl}
+      s3_table: ${backup.stg_s3_json_files} 
       _env:
-          TD_API_KEY: ${secret:td.apikey}
-          TD_API_SERVER: ${secret:endpoint}
+          TD_API_KEY: ${secret:td.backup_apikey}
+          TD_API_SERVER: ${backup.td_backup_endpoint}
+          TD_API_CDP: ${backup.td_backup_cdp_endpoint}
           AWS_BUCKET: ${backup.s3.bucket}
           AWS_ACCESS_KEY_ID: ${secret:s3.access_key_id}
           AWS_SECRET_ACCESS_KEY: ${secret:s3.secret_access_key}

--- a/tool-box/ps_backup_restore/master_seg_restore.dig
+++ b/tool-box/ps_backup_restore/master_seg_restore.dig
@@ -23,10 +23,10 @@ _export:
     
     
     +call_restore:
-        http>: https://api-cdp.treasuredata.com/audiences
+        http>: ${restore.td_restore_cdp_endpoint}/audiences
         method: POST
         headers:
-            - Authorization: "TD1 ${secret:td.apikey}"
+            - Authorization: "TD1 ${secret:td.restore_apikey}"
         content_type: application/json
         content: 
             '${td.last_results._col0}'
@@ -51,8 +51,9 @@ _export:
             image: "digdag/digdag-python:3.9"
         py>: python_script.restore_main.main
         _env:
-            TD_API_KEY: ${secret:td.apikey}
-            TD_API_SERVER: ${secret:endpoint}
+            TD_API_KEY: ${secret:td.restore_apikey}
+            TD_API_SERVER: ${restore.td_restore_endpoint}
+            TD_API_CDP: ${restore.td_restore_cdp_endpoint}
             database: ${td.database}
             ROOT_FOLDER_ID: ${restore.root_folder_id}
             AWS_BUCKET: ${restore.aws_bucket_name}

--- a/tool-box/ps_backup_restore/python_script/S3.py
+++ b/tool-box/ps_backup_restore/python_script/S3.py
@@ -1,20 +1,40 @@
 import boto3
 import json
 import os
+import pandas as pd
+import pytd
 from boto3.s3.transfer import TransferConfig
 
 
 BUCKET = os.environ['AWS_BUCKET']
 AWS_ACCESS_KEY_ID = os.environ['AWS_ACCESS_KEY_ID']
 AWS_SECRET_ACCESS_KEY = os.environ['AWS_SECRET_ACCESS_KEY']
+td_api_key = os.environ['TD_API_KEY']
+td_endpoint_base = os.environ['TD_API_SERVER']
 
-def uploadFiletoS3(s3_object_key,local_file_path):
+def uploadFiletoS3(s3_object_key,local_file_path, db_name, table_name):
     s3 = boto3.client('s3', aws_access_key_id=AWS_ACCESS_KEY_ID, aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
     config = boto3.s3.transfer.TransferConfig(multipart_chunksize=1024 * 1) #1MB
 
     try:
         s3.upload_file(local_file_path, BUCKET, s3_object_key, Config=config)
-        print(f"Wrote {s3_object_key} to S3 successfully!")
+        storeS3ObjectKeytoTD(s3_object_key, db_name, table_name)
     except Exception as e:
         raise Exception(f"Error writing the backup data to S3: {str(e)}")
 
+def storeS3ObjectKeytoTD(s3_object_key, db_name, table_name):
+  df = pd.DataFrame()
+  df['bucket'] = [BUCKET]
+  df['s3_object_key'] = [s3_object_key]
+  print(df)
+
+  try:
+    client = pytd.Client(apikey=td_api_key,endpoint=td_endpoint_base,database=db_name, default_engine='presto')
+  except BaseException:
+      raise Exception('Error calling pytd.Client')
+
+  try:
+    client.load_table_from_dataframe(df, table_name, writer='bulk_import', if_exists='append')
+  except BaseException:
+    raise Exception('Error writing table back into TD Database')
+  

--- a/tool-box/ps_backup_restore/python_script/backup_main.py
+++ b/tool-box/ps_backup_restore/python_script/backup_main.py
@@ -8,6 +8,7 @@ import python_script.S3 as s3
 
 td_api_key = os.environ['TD_API_KEY']
 td_endpoint_base = os.environ['TD_API_SERVER']
+td_api_cdp = os.environ['TD_API_CDP']
 td_home = os.environ['TD_HOME']
 
 def uploadDataToTD(data, td_write_db, td_write_table):
@@ -132,20 +133,22 @@ def writeAllSegmentstoTD(data, db_name, table):
       raise Exception(f'Write all Segments data to TD failed {ex}')
 
 
-def main(url,s3_object_key,bk_type,db_name, table):
+def main(url,s3_object_key,bk_type,db_name, table, s3_table):
   print("********************************CALL TD API***********************************")
+  url = f'{td_api_cdp}/{url}'
   data = exportSegmentData(url)
   local_file_path = saveDatatoLocal(data)
   print("********************************WRITE RESULT TO S3***********************************")
-  s3.uploadFiletoS3(s3_object_key,local_file_path)
+  s3.uploadFiletoS3(s3_object_key,local_file_path, db_name, s3_table)
   print("********************************WRITE RESULT TO TD***********************************")
   if bk_type == 'folder_config':
     writeFolderConfigtoTD(data, db_name, table)
   elif bk_type == 'master_segment':
     writeMasterSegmenttoTD(data,db_name,table)
 
-def main_all_segments(url,s3_object_key,db_name, read_table, write_table):
+def main_all_segments(url,s3_object_key,db_name, read_table, write_table, s3_table):
   print("********************************CALL TD API***********************************")
+  url = f'{td_api_cdp}/{url}'
   segments = getListSegmentsfromTD(db_name, read_table)
   list_segments = list(segments.split(","))
   data = []
@@ -159,4 +162,4 @@ def main_all_segments(url,s3_object_key,db_name, read_table, write_table):
   print("********************************WRITE RESULT TO TD***********************************")
   writeAllSegmentstoTD(data_json, db_name, write_table)
   print("********************************WRITE RESULT TO S3***********************************")
-  s3.uploadFiletoS3(s3_object_key,local_file_path)
+  s3.uploadFiletoS3(s3_object_key,local_file_path,db_name,s3_table)

--- a/tool-box/ps_backup_restore/python_script/restore_main.py
+++ b/tool-box/ps_backup_restore/python_script/restore_main.py
@@ -106,7 +106,7 @@ def create_folder_struct(p_id, c_id):
             if row.current_node_id == int(f['id']):
                 f['relationships']['parentFolder']['data']['id'] = str(p_id)
                 r = requests.post(f"{td_cdp_endpoint}/entities/folders",headers=headers,data=json.dumps(f))
-                r.raise_for_status()
+                # r.raise_for_status()
                 resp = r.json()
                 if "data" in resp:
                     folder_dict[row.current_node_id] = resp["data"]["id"]
@@ -161,7 +161,7 @@ def create_entity(c_id):
                                 condition['id'] = str(ref_id)
                 f['relationships']['parentFolder']['data']['id'] = str(p_id)
                 r = requests.post(f"{td_cdp_endpoint}/entities/segments",headers=headers,data=json.dumps(f))
-                r.raise_for_status()
+                # r.raise_for_status()
                 resp = r.json()
                 if "data" in resp:
                     segment_dict[int(df_2['current_node_id'].values[0])] = resp["data"]["id"]


### PR DESCRIPTION
This pull request includes the following changes:
- Separated the server to have distinct endpoint URLs and API keys for backup and restoration workflows, instead of using the same ones.
- Added a new table in the backup workflow to store the S3 file paths when successfully uploading to S3.
- Relocating URL Endpoint Configuration from Hardcoded Values to YML File

1. TD Secrets: 
**Add 2 secrets**
- `td.backup_apikey` - Master/Write-only API Key of the user for the backup server
- `td.restore_apikey` - Master/Write-only API Key of the user for the restore server
2. config/backup_parent_seg.yml
**Added three parameters:** 
- `td_backup_endpoint`: The endpoint of the backup server
- `td_backup_cdp_endpoint`: The cdp endpoint of the backup server
- `stg_s3_json_files`: The table that contains the S3 file paths of the Parent Segment, Folder configuration, and all Segments for each run of the backup workflow.

 **Removed one parameter:**
- ` s3.connection_name`: This value is no longer used since the S3 credential stored in the TD secrets applies to all the connections.
4. config/restore_parent_seg.yml
**Added two parameters**
- `td_restore_endpoint`: The endpoint of the restore server
- `td_restore_cdp_endpoint`: The cdp endpoint of the restore server