### PR TITLE
Add note for policy ingestion task

### DIFF
--- a/scenarios/monitoring/basic_monitoring/initial_ingest_policy.dig
+++ b/scenarios/monitoring/basic_monitoring/initial_ingest_policy.dig
@@ -3,7 +3,7 @@ _export:
 
 +initial_database_and_tables:
     +create_db:
-        td_ddl>: 
+        td_ddl>:
         create_databases: [ "${td.database}" ]
 
 +ingest_users:
@@ -27,6 +27,8 @@ _export:
     _env:
         TD_API_KEY: ${secret:td.apikey}
 
+# This task ingests policy history for Policy Based Permission.
+# If the feature is unavailable for your account, remove this task.
 +ingest_policy:
     py>: scripts.ingest_policy.run
     dest_db: ${td.database}


### PR DESCRIPTION
Ingest policy script uses API for PBP. If this feature is not available, the feature will not work well.
https://github.com/treasure-data/treasure-boxes/blob/master/scenarios/monitoring/basic_monitoring/scripts/ingest_policy.py

Added comments to ~README and~ `initial_ingest_policy.dig`.